### PR TITLE
Develop FW-878: sock API extensions and UDP application migrations

### DIFF
--- a/bsp/boards/python/openwsnmodule_obj.h
+++ b/bsp/boards/python/openwsnmodule_obj.h
@@ -28,7 +28,6 @@
 #include "icmpv6rpl_obj.h"
 #include "coap_obj.h"
 #include "oscore_obj.h"
-#include "udp_obj.h"
 #include "idmanager_obj.h"
 #include "openqueue_obj.h"
 #include "openrandom_obj.h"
@@ -42,7 +41,6 @@
 #include "cstorm_obj.h"
 #include "cwellknown_obj.h"
 #include "rrt_obj.h"
-#include "uecho_obj.h"
 #include "uinject_obj.h"
 #include "userialbridge_obj.h"
 
@@ -206,7 +204,6 @@ struct OpenMote {
     // l4
     icmpv6echo_vars_t icmpv6echo_vars;
     icmpv6rpl_vars_t icmpv6rpl_vars;
-    openudp_vars_t openudp_vars;
     // l3
     monitor_expiration_vars_t monitor_expiration_vars;
     frag_vars_t frag_vars;
@@ -242,7 +239,6 @@ struct OpenMote {
     cwellknown_vars_t cwellknown_vars;
     rrt_vars_t rrt_vars;
     cjoin_vars_t cjoin_vars;
-    uecho_vars_t uecho_vars;
     uinject_vars_t uinject_vars;
     userialbridge_vars_t userialbridge_vars;
 };

--- a/drivers/common/openserial.c
+++ b/drivers/common/openserial.c
@@ -236,8 +236,10 @@ owerror_t openserial_printf(char *buffer, ...) {
 #ifdef BOARD_OPENSERIAL_PRINTF
     uint8_t  i;
     char *ptr, *tmp;
+    char c;
+    void* p;
     int d;
-    char intgr[16];
+    char buf[16];
     char *fail = " - unknown format specifier - ";
 
     uint8_t  asn[5];
@@ -261,6 +263,10 @@ owerror_t openserial_printf(char *buffer, ...) {
         if (*ptr == '%') {
               ptr++;
               switch (*ptr) {
+                  case 'c':
+                      c = va_arg(ap, int);
+                      outputHdlcWrite(c);
+                      break;
                   case 's':
                       tmp = va_arg(ap, char*);
                       while (*tmp != '\0'){
@@ -270,8 +276,8 @@ owerror_t openserial_printf(char *buffer, ...) {
                       break;
                   case 'd':
                       d = va_arg(ap, int);
-                      snprintf(intgr, 16, "%d", d);
-                      tmp = intgr;
+                      snprintf(buf, 16, "%d", d);
+                      tmp = buf;
                       while (*tmp != '\0'){
                           outputHdlcWrite(*tmp);
                           tmp++;
@@ -279,8 +285,17 @@ owerror_t openserial_printf(char *buffer, ...) {
                       break;
                   case 'x':
                       d = va_arg(ap, int);
-                      snprintf(intgr, 16, "%x", d);
-                      tmp = intgr;
+                      snprintf(buf, 16, "%x", d);
+                      tmp = buf;
+                      while (*tmp != '\0'){
+                          outputHdlcWrite(*tmp);
+                          tmp++;
+                      }
+                      break;
+                  case 'p':
+                      p = va_arg(ap, void*);
+                      snprintf(buf, 16, "%p", p);
+                      tmp = buf;
                       while (*tmp != '\0'){
                           outputHdlcWrite(*tmp);
                           tmp++;

--- a/inc/SConscript
+++ b/inc/SConscript
@@ -5,6 +5,7 @@ Import('env')
 localEnv = env.Clone()
 
 sources_h = [
+    'errno.h',
     'config.h',
     'check_config.h',
     'opendefs.h',

--- a/inc/SConscript
+++ b/inc/SConscript
@@ -5,7 +5,7 @@ Import('env')
 localEnv = env.Clone()
 
 sources_h = [
-    'errno.h',
+    'af.h',
     'config.h',
     'check_config.h',
     'opendefs.h',

--- a/inc/af.h
+++ b/inc/af.h
@@ -1,0 +1,24 @@
+#ifndef OPENWSN_AF_H
+#define OPENWSN_AF_H
+
+/**
+\brief Address families definitions
+*/
+
+enum {
+    AF_UNSPEC = 0,              /**< unspecified address family */
+#define AF_UNSPEC   AF_UNSPEC   /**< unspecified address family (as macro) */
+    AF_UNIX,                    /**< local to host (pipes, portals) address family. */
+#define AF_UNIX     AF_UNIX     /**< unspecified address family (as macro) */
+    AF_PACKET,                  /**< packet family */
+#define AF_PACKET   AF_PACKET   /**< packet family (as macro) */
+    AF_INET,                    /**< internetwork address family: UDP, TCP, etc. */
+#define AF_INET     AF_INET     /**< internetwork address family: UDP, TCP, etc. (as macro) */
+    AF_INET6,                   /**< internetwork address family with IPv6: UDP, TCP, etc. */
+#define AF_INET6    AF_INET6    /**< internetwork address family with IPv6: UDP, TCP, etc. (as macro) */
+    AF_NUMOF,                   /**< maximum number of address families on this system */
+#define AF_NUMOF    AF_NUMOF    /**< maximum number of address families on this system (as macro) */
+#define AF_MAX      AF_NUMOF    /**< alias for @ref AF_NUMOF */
+};
+
+#endif /* OPENWSN_AF_H */

--- a/inc/check_config.h
+++ b/inc/check_config.h
@@ -114,4 +114,12 @@
 #error "CoAP requires a transport layer, i.e. UDP or TCP."
 #endif
 
+#if defined(OPENWSN_USERIALBRIDGE_C)
+#warning "Deprecated: openserialbridge is no longer used in OpenWSN"
+#endif
+
+#if defined(OPENWSN_UEXPIRATION_C)
+#warning "Deprecated: uexpiration is not compatible with the new sock udp api"
+#endif
+
 #endif /* OPENWSN_CHECK_CONFIG_H */

--- a/inc/check_config.h
+++ b/inc/check_config.h
@@ -87,7 +87,7 @@
 
 #if !defined(OPENWSN_UDP_C) && (\
     defined(OPENWSN_USERIALBRIDGE_C) || \
-    defined(OPENWN_UECHO_C) || \
+    defined(OPENWSN_UECHO_C) || \
     defined(OPENWSN_UINJECT_C) || \
     defined(OPENWSN_USERIALBRIDGE_C) || \
     defined(OPENWSN_UEXPIRATION_C) || \

--- a/inc/config.h
+++ b/inc/config.h
@@ -290,6 +290,13 @@
  */
 #define PACKETQUEUE_LENGTH              20
 
+/**
+ * \def DEADLINE_OPTION_ENABLED
+ *
+ * Enables IPv6 Deadline hop-by-hop forwarding to upper layers
+ *
+ */
+#define DEADLINE_OPTION_ENABLED
 // ======================== Board configuration ========================
 
 /**

--- a/inc/errno.h
+++ b/inc/errno.h
@@ -1,9 +1,0 @@
-#ifndef OPENWSN_ERRNO_H
-#define OPENWSN_ERRNO_H
-
-#define ENOMEM                         1
-#define EINVAL                         2
-#define EADDRINUSE                     3
-#define EAFNOSUPPORT                   4
-
-#endif /* OPENWSN_ERRNO_H */

--- a/inc/errno.h
+++ b/inc/errno.h
@@ -1,0 +1,9 @@
+#ifndef OPENWSN_ERRNO_H
+#define OPENWSN_ERRNO_H
+
+#define ENOMEM                         1
+#define EINVAL                         2
+#define EADDRINUSE                     3
+#define EAFNOSUPPORT                   4
+
+#endif /* OPENWSN_ERRNO_H */

--- a/inc/opendefs.h
+++ b/inc/opendefs.h
@@ -336,7 +336,7 @@ typedef struct {
    uint8_t*      payload;                                       // pointer to the start of the payload within 'packet'
    int16_t       length;                                        // length in bytes of the payload
    //l7
-#if defined(DEADLINE_OPTION)
+#if defined(DEADLINE_OPTION_ENABLED)
    uint16_t      max_delay;                                     // Max delay in milliseconds before which the packet should be delivered to the receiver
    bool          orgination_time_flag;
    bool          drop_flag;

--- a/inc/opendefs.h
+++ b/inc/opendefs.h
@@ -52,79 +52,83 @@ static const uint8_t infoStackName[] = "OpenWSN ";
 #endif
 
 enum {
-   E_SUCCESS                           = 0,
-   E_FAIL                              = 1,
+    E_SUCCESS = 0,
+    E_FAIL = 1,
+};
+
+// address families
+enum {
+    AF_INET6 = 1,
 };
 
 // types of addresses
 enum {
-   ADDR_NONE                           = 0,
-   ADDR_16B                            = 1,
-   ADDR_64B                            = 2,
-   ADDR_128B                           = 3,
-   ADDR_PANID                          = 4,
-   ADDR_PREFIX                         = 5,
-   ADDR_ANYCAST                        = 6,
+    ADDR_NONE = 0,
+    ADDR_16B = 1,
+    ADDR_64B = 2,
+    ADDR_128B = 3,
+    ADDR_PANID = 4,
+    ADDR_PREFIX = 5,
+    ADDR_ANYCAST = 6,
 };
 
 enum {
-   OW_LITTLE_ENDIAN                    = TRUE,
-   OW_BIG_ENDIAN                       = FALSE,
+    OW_LITTLE_ENDIAN = TRUE,
+    OW_BIG_ENDIAN = FALSE,
 };
 
 // protocol numbers, as defined by the IANA
 enum {
-   IANA_IPv6HOPOPT                     = 0x00,
-   IANA_UDP                            = 0x11,
-   IANA_IPv6ROUTING                    = 0x03,
-   IANA_IPv6ROUTE                      = 0x2b,//used for source routing
-   IANA_ICMPv6                         = 0x3a,
-   IANA_ICMPv6_ECHO_REQUEST            =  128,
-   IANA_ICMPv6_ECHO_REPLY              =  129,
-   IANA_ICMPv6_RS                      =  133,
-   IANA_ICMPv6_RA                      =  134,
-   IANA_ICMPv6_RA_PREFIX_INFORMATION   =    3,
-   IANA_ICMPv6_RPL                     =  155,
-   IANA_ICMPv6_RPL_DIS                 = 0x00,
-   IANA_ICMPv6_RPL_DIO                 = 0x01,
-   IANA_ICMPv6_RPL_DAO                 = 0x02,
-   IANA_RSVP                           =   46,
-   IANA_UNDEFINED                      =  250, //use an unassigned
+    IANA_IPv6HOPOPT = 0x00,
+    IANA_UDP = 0x11,
+    IANA_IPv6ROUTING = 0x03,
+    IANA_IPv6ROUTE = 0x2b,//used for source routing
+    IANA_ICMPv6 = 0x3a,
+    IANA_ICMPv6_ECHO_REQUEST = 128,
+    IANA_ICMPv6_ECHO_REPLY = 129,
+    IANA_ICMPv6_RS = 133,
+    IANA_ICMPv6_RA = 134,
+    IANA_ICMPv6_RA_PREFIX_INFORMATION = 3,
+    IANA_ICMPv6_RPL = 155,
+    IANA_ICMPv6_RPL_DIS = 0x00,
+    IANA_ICMPv6_RPL_DIO = 0x01,
+    IANA_ICMPv6_RPL_DAO = 0x02,
+    IANA_RSVP = 46,
+    IANA_UNDEFINED = 250, //use an unassigned
 };
 
 // well known ports (which we define)
-// warning: first 4 MSB of 2° octect may coincide with previous protocol number
+// warning: first 4 MSB of 2° octet may coincide with previous protocol number
 enum {
-   //UDP
-   WKP_UDP_COAP                        =    5683,
-   WKP_UDP_ECHO                        =       7,
-   WKP_UDP_EXPIRATION                  =       5,
-   WKP_UDP_MONITOR                     =       3,
-   WKP_UDP_INJECT                      =   61617,// 0xf0b1
-   WKP_UDP_RINGMASTER                  =   15000,
-   WKP_UDP_SERIALBRIDGE                =    2001,
+    //UDP
+    WKP_UDP_COAP = 5683,
+    WKP_UDP_ECHO = 7,
+    WKP_UDP_EXPIRATION = 5,
+    WKP_UDP_MONITOR = 3,
+    WKP_UDP_INJECT = 61617,// 0xf0b1
+    WKP_UDP_RINGMASTER = 15000,
+    WKP_UDP_SERIALBRIDGE = 2001,
 };
 
 //status elements
 enum {
-   STATUS_ISSYNC                       =  0,
-   STATUS_ID                           =  1,
-   STATUS_DAGRANK                      =  2,
-   STATUS_OUTBUFFERINDEXES             =  3,
-   STATUS_ASN                          =  4,
-   STATUS_MACSTATS                     =  5,
-   STATUS_SCHEDULE                     =  6,
-   STATUS_BACKOFF                      =  7,
-   STATUS_QUEUE                        =  8,
-   STATUS_NEIGHBORS                    =  9,
-   STATUS_KAPERIOD                     = 10,
-   STATUS_JOINED                       = 11,
-   STATUS_MSF                          = 12,
-   STATUS_MAX                          = 13,
+    STATUS_ISSYNC = 0,
+    STATUS_ID = 1,
+    STATUS_DAGRANK = 2,
+    STATUS_OUTBUFFERINDEXES = 3,
+    STATUS_ASN = 4,
+    STATUS_MACSTATS = 5,
+    STATUS_SCHEDULE = 6,
+    STATUS_BACKOFF = 7,
+    STATUS_QUEUE = 8,
+    STATUS_NEIGHBORS = 9,
+    STATUS_KAPERIOD = 10,
+    STATUS_JOINED = 11,
+    STATUS_MSF = 12,
+    STATUS_MAX = 13,
 };
 
-//component identifiers
-//the order is important because
+// component identifiers, order is important
 enum {
    COMPONENT_NULL                      = 0x00,
    COMPONENT_OPENWSN                   = 0x01,
@@ -164,27 +168,29 @@ enum {
    COMPONENT_ICMPv6ROUTER              = 0x17,
    COMPONENT_ICMPv6RPL                 = 0x18,
    //TRAN
-   COMPONENT_OPENUDP                   = 0x19,
-   COMPONENT_OPENCOAP                  = 0x1a,
+   COMPONENT_UDP                       = 0x19,
+   COMPONENT_SOCK_TO_UDP               = 0x1a,
+   COMPONENT_UDP_TO_SOCK               = 0x1b,
+   COMPONENT_OPENCOAP                  = 0x1c,
    // secure join
-   COMPONENT_CJOIN                     = 0x1b,
-   COMPONENT_OSCORE                    = 0x1c,
+   COMPONENT_CJOIN                     = 0x1d,
+   COMPONENT_OSCORE                    = 0x1e,
    // applications
-   COMPONENT_C6T                       = 0x1d,
-   COMPONENT_CEXAMPLE                  = 0x1e,
-   COMPONENT_CINFO                     = 0x1f,
-   COMPONENT_CLEDS                     = 0x20,
-   COMPONENT_CSENSORS                  = 0x21,
-   COMPONENT_CSTORM                    = 0x22,
-   COMPONENT_CWELLKNOWN                = 0x23,
-   COMPONENT_UECHO                     = 0x24,
-   COMPONENT_UINJECT                   = 0x25,
-   COMPONENT_RRT                       = 0x26,
-   COMPONENT_SECURITY                  = 0x27,
-   COMPONENT_USERIALBRIDGE             = 0x28,
-   COMPONENT_UEXPIRATION               = 0x29,
-   COMPONENT_UMONITOR                  = 0x2a,
-   COMPONENT_CINFRARED                 = 0x2b,
+   COMPONENT_C6T                       = 0x1f,
+   COMPONENT_CEXAMPLE                  = 0x20,
+   COMPONENT_CINFO                     = 0x21,
+   COMPONENT_CLEDS                     = 0x22,
+   COMPONENT_CSENSORS                  = 0x23,
+   COMPONENT_CSTORM                    = 0x24,
+   COMPONENT_CWELLKNOWN                = 0x25,
+   COMPONENT_UECHO                     = 0x26,
+   COMPONENT_UINJECT                   = 0x27,
+   COMPONENT_RRT                       = 0x28,
+   COMPONENT_SECURITY                  = 0x29,
+   COMPONENT_USERIALBRIDGE             = 0x2a,
+   COMPONENT_UEXPIRATION               = 0x2b,
+   COMPONENT_UMONITOR                  = 0x2c,
+   COMPONENT_CINFRARED                 = 0x2d,
 };
 
 /**
@@ -291,37 +297,38 @@ enum {
 //=========================== typedef =========================================
 
 
-typedef uint16_t  errorparameter_t;
-typedef uint16_t  dagrank_t;
-typedef uint8_t   owerror_t;
+typedef uint16_t errorparameter_t;
+typedef uint16_t dagrank_t;
+typedef uint8_t owerror_t;
 
 BEGIN_PACK
 typedef struct {
-   uint8_t  byte4;
-   uint16_t bytes2and3;
-   uint16_t bytes0and1;
+    uint8_t byte4;
+    uint16_t bytes2and3;
+    uint16_t bytes0and1;
 } asn_t;
 END_PACK
 
-typedef asn_t  macFrameCounter_t;
+typedef asn_t
+macFrameCounter_t;
 
 BEGIN_PACK
 
 typedef struct {
-    bool      isUsed;
-    uint16_t  slotoffset;
-    uint16_t  channeloffset;
+    bool isUsed;
+    uint16_t slotoffset;
+    uint16_t channeloffset;
 } cellInfo_ht;
 
-typedef struct {                                 // always written big endian, i.e. MSB in addr[0]
-   uint8_t type;
-   union {
-      uint8_t addr_16b[2];
-      uint8_t addr_64b[8];
-      uint8_t addr_128b[16];
-      uint8_t panid[2];
-      uint8_t prefix[8];
-   };
+typedef struct {  // always written big endian, i.e. MSB in addr[0]
+    uint8_t type;
+    union {
+        uint8_t addr_16b[2];
+        uint8_t addr_64b[8];
+        uint8_t addr_128b[16];
+        uint8_t panid[2];
+        uint8_t prefix[8];
+    };
 } open_addr_t;
 END_PACK
 
@@ -339,7 +346,7 @@ typedef struct {
 #endif
    bool          is_cjoin_response;
 #if defined(OPENWSN_6LO_FRAGMENTATION_C)
-   bool          is_big_packet;
+    bool is_big_packet;
 #endif
 
    //l4
@@ -411,24 +418,24 @@ typedef struct {
 
 BEGIN_PACK
 typedef struct {
-   bool             used;
-   bool             insecure;
-   uint8_t          parentPreference;
-   bool             stableNeighbor;
-   uint8_t          switchStabilityCounter;
-   open_addr_t      addr_64b;
-   dagrank_t        DAGrank;
-   int8_t           rssi;
-   uint8_t          numRx;
-   uint8_t          numTx;
-   uint8_t          numTxACK;
-   uint8_t          numWraps;//number of times the tx counter wraps. can be removed if memory is a restriction. also check openvisualizer then.
-   asn_t            asn;
-   uint8_t          joinPrio;
-   bool             f6PNORES;
-   uint8_t          sequenceNumber;
-   uint8_t          backoffExponenton;
-   uint8_t          backoff;
+    bool used;
+    bool insecure;
+    uint8_t parentPreference;
+    bool stableNeighbor;
+    uint8_t switchStabilityCounter;
+    open_addr_t addr_64b;
+    dagrank_t DAGrank;
+    int8_t rssi;
+    uint8_t numRx;
+    uint8_t numTx;
+    uint8_t numTxACK;
+    uint8_t numWraps; // number of times the tx counter wraps. can be removed if memory is a restriction. also check openvisualizer then.
+    asn_t asn;
+    uint8_t joinPrio;
+    bool f6PNORES;
+    uint8_t sequenceNumber;
+    uint8_t backoffExponenton;
+    uint8_t backoff;
 } neighborRow_t;
 END_PACK
 

--- a/inc/opendefs.h
+++ b/inc/opendefs.h
@@ -17,6 +17,8 @@
 #include "config.h"
 #include "toolchain_defs.h"
 #include "board_info.h"
+#include "af.h"
+
 
 //=========================== define ==========================================
 
@@ -54,11 +56,6 @@ static const uint8_t infoStackName[] = "OpenWSN ";
 enum {
     E_SUCCESS = 0,
     E_FAIL = 1,
-};
-
-// address families
-enum {
-    AF_INET6 = 1,
 };
 
 // types of addresses

--- a/openapps/uecho/uecho.c
+++ b/openapps/uecho/uecho.c
@@ -4,73 +4,65 @@
 
 #include "opendefs.h"
 #include "uecho.h"
+#include "sock.h"
+#include "async.h"
 #include "openqueue.h"
 #include "openserial.h"
 #include "packetfunctions.h"
 
 //=========================== variables =======================================
 
-uecho_vars_t uecho_vars;
+sock_udp_t uecho_sock;
 
 //=========================== prototypes ======================================
+
+void uecho_handler(sock_udp_t *sock, sock_async_flags_t type, void *arg);
 
 //=========================== public ==========================================
 
 void uecho_init(void) {
     // clear local variables
-    memset(&uecho_vars, 0, sizeof(uecho_vars_t));
+    memset(&uecho_sock, 0, sizeof(sock_udp_t));
 
-    // register at UDP stack
-    uecho_vars.desc.port = WKP_UDP_ECHO;
-    uecho_vars.desc.callbackReceive = &uecho_receive;
-    uecho_vars.desc.callbackSendDone = &uecho_sendDone;
-    openudp_register(&uecho_vars.desc);
-}
+    sock_udp_ep_t local;
 
-void uecho_receive(OpenQueueEntry_t *request) {
-    OpenQueueEntry_t *reply;
+    local.port = WKP_UDP_ECHO;
 
-    reply = openqueue_getFreePacketBuffer(COMPONENT_UECHO);
-
-    if (reply == NULL) {
-        LOG_ERROR(COMPONENT_UECHO, ERR_NO_FREE_PACKET_BUFFER, (errorparameter_t) 0, (errorparameter_t) 0);
-        openqueue_freePacketBuffer(request); //clear the request packet as well
+    if (sock_udp_create(&uecho_sock, &local, NULL, 0) < 0) {
+        openserial_printf("Could not create socket\n");
         return;
     }
 
-    reply->owner = COMPONENT_UECHO;
+    openserial_printf("Created a UDP socket\n");
 
-    // reply with the same OpenQueueEntry_t
-    reply->creator = COMPONENT_UECHO;
-    reply->l4_protocol = IANA_UDP;
-    reply->l4_destination_port = request->l4_sourcePortORicmpv6Type;
-    reply->l4_sourcePortORicmpv6Type = request->l4_destination_port;
-    reply->l3_destinationAdd.type = ADDR_128B;
+    sock_udp_set_cb(&uecho_sock, uecho_handler, NULL);
+}
 
-    // copy source to destination to echo.
-    memcpy(&reply->l3_destinationAdd.addr_128b[0], &request->l3_sourceAdd.addr_128b[0], 16);
+void uecho_handler(sock_udp_t *sock, sock_async_flags_t type, void *arg) {
+    (void) arg;
 
-    if (packetfunctions_reserveHeader(&reply, request->length) == E_FAIL) {
-        openqueue_freePacketBuffer(reply);
-        return;
+    char buf[50];
+
+    if (type & SOCK_ASYNC_MSG_RECV) {
+        sock_udp_ep_t remote;
+        int16_t res;
+
+        if ((res = sock_udp_recv(sock, buf, sizeof(buf), 0, &remote)) >= 0) {
+            openserial_printf("Received %d bytes from remote endpoint:\n", res);
+            openserial_printf(" - port: %d", remote.port);
+            openserial_printf(" - addr: ", remote.port);
+            for(int i=0; i < 16; i ++)
+                openserial_printf("%x ", remote.addr.ipv6[i]);
+
+            openserial_printf("\n\n");
+            openserial_printf("Msg received: %s\n\n", buf);
+
+            if (sock_udp_send(sock, buf, res, &remote) < 0) {
+                openserial_printf("Error sending reply\n");
+            }
+        }
     }
-    memcpy(&reply->payload[0], &request->payload[0], request->length);
-
-    openqueue_freePacketBuffer(request);
-
-    if ((openudp_send(reply)) == E_FAIL) {
-        openqueue_freePacketBuffer(reply);
-    }
 }
-
-void uecho_sendDone(OpenQueueEntry_t *msg, owerror_t error) {
-    openqueue_freePacketBuffer(msg);
-}
-
-bool uecho_debugPrint(void) {
-    return FALSE;
-}
-
 //=========================== private =========================================
 
 #endif /* OPENWSN_UECHO_C */

--- a/openapps/uecho/uecho.h
+++ b/openapps/uecho/uecho.h
@@ -1,5 +1,5 @@
-#ifndef __UECHO_H
-#define __UECHO_H
+#ifndef OPENWSN_UECHO_H
+#define OPENWSN_UECHO_H
 
 /**
 \addtogroup AppUdp
@@ -9,7 +9,6 @@
 */
 
 #include "config.h"
-#include "udp.h"
 
 //=========================== define ==========================================
 
@@ -17,23 +16,13 @@
 
 //=========================== variables =======================================
 
-typedef struct {
-    udp_resource_desc_t desc;  ///< resource descriptor for this module, used to register at UDP stack
-} uecho_vars_t;
-
 //=========================== prototypes ======================================
 
 void uecho_init(void);
-
-void uecho_receive(OpenQueueEntry_t *msg);
-
-void uecho_sendDone(OpenQueueEntry_t *msg, owerror_t error);
-
-bool uecho_debugPrint(void);
 
 /**
 \}
 \}
 */
 
-#endif
+#endif /* OPENWSN_UECHO_H */

--- a/openapps/uexpiration/uexpiration.c
+++ b/openapps/uexpiration/uexpiration.c
@@ -33,7 +33,6 @@ void uexpiration_init(void) {
     uexpiration_vars.desc.port = WKP_UDP_EXPIRATION;
     uexpiration_vars.desc.callbackReceive = &uexpiration_receive;
     uexpiration_vars.desc.callbackSendDone = &uexpiration_sendDone;
-    openudp_register(&uexpiration_vars.desc);
 }
 
 void uexpiration_receive(OpenQueueEntry_t *request) {
@@ -137,9 +136,6 @@ void uexpiration_task_cb(void) {
         );
     }
 
-    if ((openudp_send(reply)) == E_FAIL) {
-        openqueue_freePacketBuffer(reply);
-    }
 
 }
 

--- a/openapps/uexpiration/uexpiration.h
+++ b/openapps/uexpiration/uexpiration.h
@@ -20,7 +20,6 @@
 typedef struct {
     opentimers_id_t timerId;  ///< periodic timer which triggers transmission
     uint16_t period;  ///< uinject packet sending period>
-    udp_resource_desc_t desc;  ///< resource descriptor for this module, used to register at UDP stack
 } uexpiration_vars_t;
 
 //=========================== prototypes ======================================

--- a/openapps/uexpiration_monitor/uexpiration_monitor.c
+++ b/openapps/uexpiration_monitor/uexpiration_monitor.c
@@ -13,28 +13,18 @@
 #endif
 
 //=========================== variables =======================================
-umonitor_vars_t umonitor_vars;
 
 //=========================== prototypes ======================================
 
 //=========================== public ==========================================
 
 void umonitor_init(void) {
-    // clear local variables
-    memset(&umonitor_vars, 0, sizeof(umonitor_vars_t));
-
-    // register at UDP stack
-    umonitor_vars.desc.port = WKP_UDP_MONITOR;
-    umonitor_vars.desc.callbackReceive = &umonitor_receive;
-    umonitor_vars.desc.callbackSendDone = &umonitor_sendDone;
-    openudp_register(&umonitor_vars.desc);
 }
 
 void umonitor_receive(OpenQueueEntry_t *request) {
     uint16_t temp_l4_destination_port;
     OpenQueueEntry_t *reply;
 #ifdef DEADLINE_OPTION_ENABLED
-    monitor_expiration_vars_t	deadline;
 #endif
 
     reply = openqueue_getFreePacketBuffer(COMPONENT_UMONITOR);
@@ -60,16 +50,12 @@ void umonitor_receive(OpenQueueEntry_t *request) {
         return;
     }
 #ifdef DEADLINE_OPTION_ENABLED
-    memset(&deadline, 0, sizeof(monitor_expiration_vars_t));
     iphc_getDeadlineInfo(&deadline);
     memcpy(&reply->payload[0],&deadline.time_elapsed,sizeof(uint16_t));
     memcpy(&reply->payload[2],&deadline.time_left,sizeof(uint16_t));
 #endif
     openqueue_freePacketBuffer(request);
 
-    if ((openudp_send(reply)) == E_FAIL) {
-        openqueue_freePacketBuffer(reply);
-    }
 }
 
 void umonitor_sendDone(OpenQueueEntry_t *msg, owerror_t error) {

--- a/openapps/uexpiration_monitor/uexpiration_monitor.c
+++ b/openapps/uexpiration_monitor/uexpiration_monitor.c
@@ -4,7 +4,8 @@
 
 #include "opendefs.h"
 #include "uexpiration_monitor.h"
-#include "openqueue.h"
+#include "sock.h"
+#include "async.h"
 #include "openserial.h"
 #include "packetfunctions.h"
 
@@ -14,58 +15,56 @@
 
 //=========================== variables =======================================
 
+static sock_udp_t _sock;
+
 //=========================== prototypes ======================================
+
+//=========================== private =========================================
+
+void _sock_handler(sock_udp_t *sock, sock_async_flags_t type, void *arg) {
+    (void) arg;
+
+    uint8_t buf[50];
+    if (type & SOCK_ASYNC_MSG_RECV) {
+        sock_udp_ep_t remote;
+        if (sock_udp_recv(sock, buf, sizeof(buf), 0, &remote) >= 0) {
+            size_t len = 0;
+#ifdef DEADLINE_OPTION_ENABLED
+            monitor_expiration_vars_t deadline = { 0 };
+            iphc_getDeadlineInfo(&deadline);
+            memcpy(&buf[0], &deadline.time_elapsed, sizeof(uint16_t));
+            len += sizeof(uint16_t);
+            memcpy(&buf[2], &deadline.time_left, sizeof(int16_t));
+            len += sizeof(int16_t);
+#endif
+            if (sock_udp_send(sock, (char*) buf, len, &remote) < 0) {
+                LOG_ERROR(COMPONENT_UMONITOR, ERR_PUSH_LOWER_LAYER,
+                          (errorparameter_t) 0,
+                          (errorparameter_t) 0);
+            }
+        }
+    }
+}
 
 //=========================== public ==========================================
 
-void umonitor_init(void) {
-}
+void umonitor_init(void)
+{
+    // clear local variables
+    memset(&_sock, 0, sizeof(sock_udp_t));
 
-void umonitor_receive(OpenQueueEntry_t *request) {
-    uint16_t temp_l4_destination_port;
-    OpenQueueEntry_t *reply;
-#ifdef DEADLINE_OPTION_ENABLED
-#endif
+    sock_udp_ep_t local;
+    local.family = AF_INET6;
+    local.port = WKP_UDP_MONITOR;
 
-    reply = openqueue_getFreePacketBuffer(COMPONENT_UMONITOR);
-    if (reply == NULL) {
-        LOG_ERROR(COMPONENT_UMONITOR, ERR_NO_FREE_PACKET_BUFFER, (errorparameter_t) 0, (errorparameter_t) 0);
-        openqueue_freePacketBuffer(request); //clear the request packet as well
+    if (sock_udp_create(&_sock, &local, NULL, 0) < 0) {
+        LOG_ERROR(COMPONENT_UMONITOR, ERR_INVALID_PARAM,
+                (errorparameter_t) 0,
+                (errorparameter_t) 0);
         return;
     }
 
-    reply->owner = COMPONENT_UMONITOR;
-    reply->creator = COMPONENT_UMONITOR;
-    reply->l4_protocol = IANA_UDP;
-    temp_l4_destination_port = request->l4_destination_port;
-    reply->l4_destination_port = request->l4_sourcePortORicmpv6Type;
-    reply->l4_sourcePortORicmpv6Type = temp_l4_destination_port;
-    reply->l3_destinationAdd.type = ADDR_128B;
-    memcpy(&reply->l3_destinationAdd.addr_128b[0], &request->l3_sourceAdd.addr_128b[0], 16);
-
-    /*************** Packet Payload  ********************/
-    // [Expiration time, Delay]
-    if (packetfunctions_reserveHeader(&reply, (2 * sizeof(uint16_t))) == E_FAIL) {
-        openqueue_freePacketBuffer(reply);
-        return;
-    }
-#ifdef DEADLINE_OPTION_ENABLED
-    iphc_getDeadlineInfo(&deadline);
-    memcpy(&reply->payload[0],&deadline.time_elapsed,sizeof(uint16_t));
-    memcpy(&reply->payload[2],&deadline.time_left,sizeof(uint16_t));
-#endif
-    openqueue_freePacketBuffer(request);
-
+    sock_udp_set_cb(&_sock, _sock_handler, NULL);
 }
-
-void umonitor_sendDone(OpenQueueEntry_t *msg, owerror_t error) {
-    openqueue_freePacketBuffer(msg);
-}
-
-bool umonitor_debugPrint(void) {
-    return FALSE;
-}
-
-//=========================== private =========================================
 
 #endif /* OPEWSN_UEXP_MONITOR_C */

--- a/openapps/uexpiration_monitor/uexpiration_monitor.h
+++ b/openapps/uexpiration_monitor/uexpiration_monitor.h
@@ -17,9 +17,6 @@
 
 //=========================== variables =======================================
 
-typedef struct {
-    udp_resource_desc_t desc;  ///< resource descriptor for this module, used to register at UDP stack
-} umonitor_vars_t;
 
 //=========================== prototypes ======================================
 

--- a/openapps/uexpiration_monitor/uexpiration_monitor.h
+++ b/openapps/uexpiration_monitor/uexpiration_monitor.h
@@ -22,12 +22,6 @@
 
 void umonitor_init(void);
 
-void umonitor_receive(OpenQueueEntry_t *msg);
-
-void umonitor_sendDone(OpenQueueEntry_t *msg, owerror_t error);
-
-bool umonitor_debugPrint(void);
-
 /**
 \}
 \}

--- a/openapps/uinject/uinject.c
+++ b/openapps/uinject/uinject.c
@@ -4,7 +4,8 @@
 
 #include "opendefs.h"
 #include "uinject.h"
-#include "openqueue.h"
+#include "sock.h"
+#include "async.h"
 #include "openserial.h"
 #include "packetfunctions.h"
 #include "scheduler.h"
@@ -22,7 +23,8 @@
 
 //=========================== variables =======================================
 
-uinject_vars_t uinject_vars;
+static sock_udp_t _sock;
+static uinject_vars_t uinject_vars;
 
 static const uint8_t uinject_payload[] = "uinject";
 static const uint8_t uinject_dst_addr[] = {
@@ -31,74 +33,95 @@ static const uint8_t uinject_dst_addr[] = {
 
 //=========================== prototypes ======================================
 
-void uinject_timer_cb(opentimers_id_t id);
+void _sock_handler(sock_udp_t *sock, sock_async_flags_t type, void *arg);
 
-void uinject_task_cb(void);
+void _uinject_timer_cb(opentimers_id_t id);
+
+void _uinject_task_cb(void);
 
 //=========================== public ==========================================
 
 void uinject_init(void) {
 
     // clear local variables
+    memset(&_sock, 0, sizeof(sock_udp_t));
     memset(&uinject_vars, 0, sizeof(uinject_vars_t));
 
-    // register at UDP stack
-    uinject_vars.desc.port = WKP_UDP_INJECT;
-    uinject_vars.desc.callbackReceive = &uinject_receive;
-    uinject_vars.desc.callbackSendDone = &uinject_sendDone;
+    sock_udp_ep_t local;
+    local.family = AF_INET6;
+    local.port = WKP_UDP_INJECT;
 
-    uinject_vars.period = UINJECT_PERIOD_MS;
+    if (sock_udp_create(&_sock, &local, NULL, 0) < 0) {
+        openserial_printf("Could not create socket\n");
+        return;
+    }
+
+    openserial_printf("Created a UDP socket\n");
+
+    sock_udp_set_cb(&_sock, _sock_handler, NULL);
+
     // start periodic timer
+    uinject_vars.period = UINJECT_PERIOD_MS;
     uinject_vars.timerId = opentimers_create(TIMER_GENERAL_PURPOSE, TASKPRIO_UDP);
     opentimers_scheduleIn(
             uinject_vars.timerId,
             UINJECT_PERIOD_MS,
             TIME_MS,
             TIMER_PERIODIC,
-            uinject_timer_cb
+            _uinject_timer_cb
     );
-}
-
-void uinject_sendDone(OpenQueueEntry_t *msg, owerror_t error) {
-
-    if (error == E_FAIL) {
-        LOG_ERROR(COMPONENT_UINJECT, ERR_MAXRETRIES_REACHED,
-                  (errorparameter_t) uinject_vars.counter,
-                  (errorparameter_t) 0
-        );
-    }
-
-    // free the packet buffer entry
-    openqueue_freePacketBuffer(msg);
-
-    // allow send next uinject packet
-    uinject_vars.busySendingUinject = FALSE;
-}
-
-void uinject_receive(OpenQueueEntry_t *pkt) {
-
-    openqueue_freePacketBuffer(pkt);
 }
 
 //=========================== private =========================================
 
-void uinject_timer_cb(opentimers_id_t id) {
-    // calling the task directly as the timer_cb function is executed in
-    // task mode by opentimer already
-    if (openrandom_get16b() < (0xffff / UINJECT_TRAFFIC_RATE)) {
-        uinject_task_cb();
+
+
+void _sock_handler(sock_udp_t *sock, sock_async_flags_t type, void *arg) {
+    (void) arg;
+
+    char buf[50];
+
+    if (type & SOCK_ASYNC_MSG_RECV) {
+        sock_udp_ep_t remote;
+        int16_t res;
+
+        if ((res = sock_udp_recv(sock, buf, sizeof(buf), 0, &remote)) >= 0) {
+            openserial_printf("Received %d bytes from remote endpoint:\n", res);
+            openserial_printf(" - port: %d", remote.port);
+            openserial_printf(" - addr: ", remote.port);
+            for(int i=0; i < 16; i ++)
+                openserial_printf("%x ", remote.addr.ipv6[i]);
+
+            openserial_printf("\n\n");
+            openserial_printf("Msg received: %s\n\n", buf);
+        }
+    }
+
+    if (type & SOCK_ASYNC_MSG_SENT) {
+        owerror_t error = *(uint8_t*)arg;
+        if (error == E_FAIL) {
+            LOG_ERROR(COMPONENT_UINJECT, ERR_MAXRETRIES_REACHED,
+                    (errorparameter_t) uinject_vars.counter,
+                    (errorparameter_t) 0);
+        }
+        // allow send next uinject packet
+        uinject_vars.busySendingUinject = FALSE;
     }
 }
 
-void uinject_task_cb(void) {
-    OpenQueueEntry_t *pkt;
+
+void _uinject_timer_cb(opentimers_id_t id) {
+    // calling the task directly as the timer_cb function is executed in
+    // task mode by opentimer already
+    if (openrandom_get16b() < (0xffff / UINJECT_TRAFFIC_RATE)) {
+        _uinject_task_cb();
+    }
+}
+
+void _uinject_task_cb(void) {
     uint8_t asnArray[5];
-    uint8_t numCellsUsed;
     open_addr_t parentNeighbor;
     bool foundNeighbor;
-
-    uint32_t ticksOn;
-    uint32_t ticksInTotal;
 
     // don't run if not synch
     if (ieee154e_isSynch() == FALSE) {
@@ -126,95 +149,44 @@ void uinject_task_cb(void) {
     }
 
     // if you get here, send a packet
+    sock_udp_ep_t remote;
+    remote.port = WKP_UDP_INJECT;
+    remote.family = AF_INET6;
+    memcpy(remote.addr.ipv6, uinject_dst_addr, sizeof(uinject_dst_addr));
 
-    // get a free packet buffer
-    pkt = openqueue_getFreePacketBuffer(COMPONENT_UINJECT);
-    if (pkt == NULL) {
-        LOG_ERROR(COMPONENT_UINJECT, ERR_NO_FREE_PACKET_BUFFER, (errorparameter_t) 0, (errorparameter_t) 0);
-        return;
-    }
-
-    pkt->owner = COMPONENT_UINJECT;
-    pkt->creator = COMPONENT_UINJECT;
-    pkt->l4_protocol = IANA_UDP;
-    pkt->l4_destination_port = WKP_UDP_INJECT;
-    pkt->l4_sourcePortORicmpv6Type = WKP_UDP_INJECT;
-    pkt->l3_destinationAdd.type = ADDR_128B;
-    memcpy(&pkt->l3_destinationAdd.addr_128b[0], uinject_dst_addr, 16);
-
-    // add payload
-    if (packetfunctions_reserveHeader(&pkt, sizeof(uinject_payload) - 1) == E_FAIL) {
-        openqueue_freePacketBuffer(pkt);
-        return;
-    }
-    memcpy(&pkt->payload[0], uinject_payload, sizeof(uinject_payload) - 1);
-
-    if (packetfunctions_reserveHeader(&pkt, sizeof(uint16_t)) == E_FAIL) {
-        openqueue_freePacketBuffer(pkt);
-        return;
-    }
-
-    pkt->payload[1] = (uint8_t)((uinject_vars.counter & 0xff00) >> 8);
-    pkt->payload[0] = (uint8_t)(uinject_vars.counter & 0x00ff);
+    uint8_t payload[50];
+    uint8_t len = 0;
+    // add 'uinject' string
+    memcpy(&payload[len], uinject_payload, sizeof(uinject_payload) - 1);
+    len += sizeof(uinject_payload) - 1;
+    // add counter
+    payload[len++] = (uint8_t)(uinject_vars.counter & 0x00ff);
+    payload[len++] = (uint8_t)((uinject_vars.counter & 0xff00) >> 8);
     uinject_vars.counter++;
-
-    if (packetfunctions_reserveHeader(&pkt, sizeof(asn_t)) == E_FAIL) {
-        openqueue_freePacketBuffer(pkt);
-        return;
-    }
-
-
+    // add asn
     ieee154e_getAsn(asnArray);
-    pkt->payload[0] = asnArray[0];
-    pkt->payload[1] = asnArray[1];
-    pkt->payload[2] = asnArray[2];
-    pkt->payload[3] = asnArray[3];
-    pkt->payload[4] = asnArray[4];
-
-    if (packetfunctions_reserveHeader(&pkt, sizeof(uint8_t)) == E_FAIL) {
-        openqueue_freePacketBuffer(pkt);
-        return;
-    }
-    numCellsUsed = msf_getPreviousNumCellsUsed(CELLTYPE_TX);
-    pkt->payload[0] = numCellsUsed;
-
-    if (packetfunctions_reserveHeader(&pkt, sizeof(uint8_t)) == E_FAIL) {
-        openqueue_freePacketBuffer(pkt);
-        return;
-    }
-
-    numCellsUsed = msf_getPreviousNumCellsUsed(CELLTYPE_RX);
-    pkt->payload[0] = numCellsUsed;
-
-    if (packetfunctions_reserveHeader(&pkt, sizeof(uint16_t)) == E_FAIL) {
-        openqueue_freePacketBuffer(pkt);
-        return;
-    }
-
-    pkt->payload[1] = (uint8_t)(idmanager_getMyID(ADDR_16B)->addr_16b[0]);
-    pkt->payload[0] = (uint8_t)(idmanager_getMyID(ADDR_16B)->addr_16b[1]);
-
+    memcpy(&payload[len], asnArray, sizeof(asnArray));
+    len += sizeof(asnArray);
+    // add tx cells used
+    payload[len++] = msf_getPreviousNumCellsUsed(CELLTYPE_TX);
+    // add rx cells used
+    payload[len++] = msf_getPreviousNumCellsUsed(CELLTYPE_RX);
+    // add 16b addr
+    payload[len++] = (uint8_t)(idmanager_getMyID(ADDR_16B)->addr_16b[1]);
+    payload[len++] = (uint8_t)(idmanager_getMyID(ADDR_16B)->addr_16b[0]);
+    // add ticks info
+    uint32_t ticksOn;
+    uint32_t ticksInTotal;
     ieee154e_getTicsInfo(&ticksOn, &ticksInTotal);
+    memcpy(&payload[len], (uint8_t*) ticksOn, sizeof(ticksOn));
+    len += sizeof(ticksOn);
+    memcpy(&payload[len], (uint8_t*) ticksInTotal, sizeof(ticksInTotal));
+    len += sizeof(ticksInTotal);
 
-    if (packetfunctions_reserveHeader(&pkt, sizeof(uint32_t)) == E_FAIL) {
-        openqueue_freePacketBuffer(pkt);
-        return;
+    if (sock_udp_send(&_sock, payload, len, &remote) > 0) {
+        // set busySending to TRUE
+        uinject_vars.busySendingUinject = TRUE;
     }
-
-    pkt->payload[3] = (uint8_t)((ticksOn & 0xff000000) >> 24);
-    pkt->payload[2] = (uint8_t)((ticksOn & 0x00ff0000) >> 16);
-    pkt->payload[1] = (uint8_t)((ticksOn & 0x0000ff00) >> 8);
-    pkt->payload[0] = (uint8_t)(ticksOn & 0x000000ff);
-
-    if (packetfunctions_reserveHeader(&pkt, sizeof(uint32_t)) == E_FAIL) {
-        openqueue_freePacketBuffer(pkt);
-        return;
-    }
-    pkt->payload[3] = (uint8_t)((ticksInTotal & 0xff000000) >> 24);
-    pkt->payload[2] = (uint8_t)((ticksInTotal & 0x00ff0000) >> 16);
-    pkt->payload[1] = (uint8_t)((ticksInTotal & 0x0000ff00) >> 8);
-    pkt->payload[0] = (uint8_t)(ticksInTotal & 0x000000ff);
-
 }
 
 #endif /* OPENWSN_UINJECT_C */

--- a/openapps/uinject/uinject.c
+++ b/openapps/uinject/uinject.c
@@ -46,7 +46,6 @@ void uinject_init(void) {
     uinject_vars.desc.port = WKP_UDP_INJECT;
     uinject_vars.desc.callbackReceive = &uinject_receive;
     uinject_vars.desc.callbackSendDone = &uinject_sendDone;
-    openudp_register(&uinject_vars.desc);
 
     uinject_vars.period = UINJECT_PERIOD_MS;
     // start periodic timer
@@ -216,12 +215,6 @@ void uinject_task_cb(void) {
     pkt->payload[1] = (uint8_t)((ticksInTotal & 0x0000ff00) >> 8);
     pkt->payload[0] = (uint8_t)(ticksInTotal & 0x000000ff);
 
-    if ((openudp_send(pkt)) == E_FAIL) {
-        openqueue_freePacketBuffer(pkt);
-    } else {
-        // set busySending to TRUE
-        uinject_vars.busySendingUinject = TRUE;
-    }
 }
 
 #endif /* OPENWSN_UINJECT_C */

--- a/openapps/uinject/uinject.h
+++ b/openapps/uinject/uinject.h
@@ -31,9 +31,6 @@ typedef struct {
 
 void uinject_init(void);
 
-void uinject_sendDone(OpenQueueEntry_t *msg, owerror_t error);
-
-void uinject_receive(OpenQueueEntry_t *msg);
 /**
 \}
 \}

--- a/openapps/uinject/uinject.h
+++ b/openapps/uinject/uinject.h
@@ -24,7 +24,6 @@ typedef struct {
     opentimers_id_t timerId;   ///< periodic timer which triggers transmission
     uint16_t counter;  ///< incrementing counter which is written into the packet
     uint16_t period;  ///< uinject packet sending period>
-    udp_resource_desc_t desc;  ///< resource descriptor for this module, used to register at UDP stack
     bool busySendingUinject;  ///< TRUE when busy sending an uinject
 } uinject_vars_t;
 

--- a/openapps/userialbridge/userialbridge.c
+++ b/openapps/userialbridge/userialbridge.c
@@ -31,10 +31,6 @@ void userialbridge_init(void) {
     // clear local variables
     memset(&userialbridge_vars, 0, sizeof(userialbridge_vars_t));
     // register at UDP stack
-    userialbridge_vars.desc.port = WKP_UDP_SERIALBRIDGE;
-    userialbridge_vars.desc.callbackReceive = NULL;
-    userialbridge_vars.desc.callbackSendDone = &userialbridge_sendDone;
-    openudp_register(&userialbridge_vars.desc);
 }
 
 void userialbridge_sendDone(OpenQueueEntry_t *msg, owerror_t error) {
@@ -84,9 +80,6 @@ void userialbridge_task_cb(void) {
     }
     memcpy(&pkt->payload[0], &userialbridge_vars.txbuf[0], userialbridge_vars.txbufLen);
 
-    if ((openudp_send(pkt)) == E_FAIL) {
-        openqueue_freePacketBuffer(pkt);
-    }
 }
 
 #endif /* OPENWSN_USERIALBRIDGE_C */

--- a/openapps/userialbridge/userialbridge.h
+++ b/openapps/userialbridge/userialbridge.h
@@ -24,7 +24,6 @@
 typedef struct {
     uint8_t txbuf[USERIALBRIDGE_MAXPAYLEN];
     uint8_t txbufLen;
-    udp_resource_desc_t desc;  ///< resource descriptor for this module, used to register at UDP stack
 } userialbridge_vars_t;
 
 //=========================== prototypes ======================================

--- a/openstack/03a-IPHC/iphc.c
+++ b/openstack/03a-IPHC/iphc.c
@@ -1098,7 +1098,7 @@ owerror_t iphc_prependIPv6DeadlineHeader(OpenQueueEntry_t **msg) {
         asn_len = iphc_getAsnLen(asn_array);
 
         if (packetfunctions_reserveHeader(msg, asn_len) == E_FAIL) {
-            return E_FAIL
+            return E_FAIL;
         }
         memcpy(&((*msg)->payload[0]), &asn_array, asn_len * sizeof(uint8_t));
         temp_len += asn_len;

--- a/openstack/03b-IPv6/forwarding.c
+++ b/openstack/03b-IPv6/forwarding.c
@@ -247,7 +247,7 @@ void forwarding_sendDone(OpenQueueEntry_t *msg, owerror_t error) {
         switch (msg->l4_protocol) {
 #ifdef OPENWSN_UDP_C
             case IANA_UDP:
-                openudp_sendDone(msg, error);
+                udp_sendDone(msg, error);
                 break;
 #endif
             case IANA_ICMPv6:
@@ -316,7 +316,7 @@ void forwarding_receive(
         switch (msg->l4_protocol) {
 #ifdef OPENWSN_UDP_C
             case IANA_UDP:
-                openudp_receive(msg);
+                udp_receive(msg);
                 break;
 #endif
             case IANA_ICMPv6:

--- a/openstack/04-TRAN/async.c
+++ b/openstack/04-TRAN/async.c
@@ -1,0 +1,6 @@
+#include "async.h"
+
+void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *cb_arg){
+    sock->async_cb = cb;
+    sock->async_cb_arg = cb_arg;
+}

--- a/openstack/04-TRAN/async.c
+++ b/openstack/04-TRAN/async.c
@@ -1,6 +1,7 @@
 #include "async.h"
 
-void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *cb_arg){
+void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *cb_arg)
+{
     sock->async_cb = cb;
     sock->async_cb_arg = cb_arg;
 }

--- a/openstack/04-TRAN/async.h
+++ b/openstack/04-TRAN/async.h
@@ -1,0 +1,25 @@
+#ifndef OPENWSN_ASYNC_SOCKET_H
+#define OPENWSN_ASYNC_SOCKET_H
+
+#include "sock.h"
+#include "async_types.h"
+
+
+/**
+ * @brief   Event callback for @ref sock_udp_t
+ *
+ * @pre `(sock != NULL)`
+ *
+ * @param[in] sock  The sock the event happened on
+ * @param[in] flags The event flags. Expected values are
+ *                  - @ref SOCK_ASYNC_MSG_RECV,
+ *                  - @ref SOCK_ASYNC_MSG_SENT,
+ *                  - @ref SOCK_ASYNC_PATH_PROP, or
+ *                  - a combination of them.
+ * @param[in] arg   Argument provided when setting the callback using
+ *                  @ref sock_udp_set_cb(). May be NULL.
+ */
+
+void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *cb_arg);
+
+#endif /* OPENWSN_ASYNC_SOCKET_H */

--- a/openstack/04-TRAN/async.h
+++ b/openstack/04-TRAN/async.h
@@ -2,8 +2,6 @@
 #define OPENWSN_ASYNC_SOCKET_H
 
 #include "sock.h"
-#include "async_types.h"
-
 
 /**
  * @brief   Event callback for @ref sock_udp_t

--- a/openstack/04-TRAN/async_types.h
+++ b/openstack/04-TRAN/async_types.h
@@ -1,0 +1,22 @@
+#ifndef OPENWSN_ASYNC_TYPES_H
+#define OPENWSN_ASYNC_TYPES_H
+
+/**
+ * @brief   Flag types to signify asynchronous sock events
+ */
+typedef enum {
+    SOCK_ASYNC_CONN_RDY = 0x0001,  /**< Connection ready event */
+    SOCK_ASYNC_CONN_FIN = 0x0002,  /**< Connection finished event */
+    SOCK_ASYNC_CONN_RECV = 0x0004,  /**< Listener received connection event */
+    SOCK_ASYNC_MSG_RECV = 0x0010,  /**< Message received event */
+    SOCK_ASYNC_MSG_SENT = 0x0020,  /**< Message sent event */
+    SOCK_ASYNC_PATH_PROP = 0x0040,  /**< Path property changed event */
+} sock_async_flags_t;
+
+
+typedef struct sock_udp sock_udp_t;     /**< forward declare for async */
+
+// definitions asynchronous callback for socket events
+typedef void (*sock_udp_cb_t)(sock_udp_t *sock, sock_async_flags_t type, void *arg);
+
+#endif /* OPENWSN_ASYNC_TYPES_H */

--- a/openstack/04-TRAN/sock.c
+++ b/openstack/04-TRAN/sock.c
@@ -1,0 +1,272 @@
+#include "config.h"
+
+#if defined(OPENWSN_UDP_C)
+
+#include "opendefs.h"
+#include "sock.h"
+#include "sock_types.h"
+#include "async_types.h"
+#include "errno.h"
+#include "packetfunctions.h"
+#include "openqueue.h"
+#include "udp.h"
+#include "openrandom.h"
+#include "idmanager.h"
+#include "scheduler.h"
+#include "openserial.h"
+
+//============================ defines ========================================
+
+sock_udp_t *udp_socket_list;
+
+//=========================== variables =======================================
+
+//=========================== prototypes ======================================
+
+static bool _sock_valid_af(uint8_t af);
+
+static bool _sock_valid_addr(sock_ip_ep_t *ep);
+
+static void _sock_get_local_addr(open_addr_t *local);
+
+void _sock_transmit_internal(void);
+
+//============================= public ========================================
+
+void sock_udp_init(void) {
+    udp_socket_list = NULL;
+}
+
+int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local, const sock_udp_ep_t *remote, uint16_t flags) {
+    sock_udp_t *current;
+
+    if (sock == NULL) {
+        return -EINVAL;
+    }
+
+    memset(&sock->gen_sock.local, 0, sizeof(sock_udp_ep_t));
+    if (local != NULL) {
+        current = udp_socket_list;
+
+        while (current != NULL) {
+            if (current->gen_sock.local.port == local->port) {
+                return -EADDRINUSE;
+            }
+            current = current->next;
+        }
+
+        memcpy(&sock->gen_sock.local, local, sizeof(sock_udp_ep_t));
+    }
+
+    memset(&sock->gen_sock.remote, 0, sizeof(sock_udp_ep_t));
+    if (remote != NULL) {
+        if (_sock_valid_af(remote->family) == FALSE) {
+            return -EAFNOSUPPORT;
+        }
+        if (_sock_valid_addr((sock_ip_ep_t *) remote) == FALSE) {
+            return -EINVAL;
+        }
+
+        memcpy(&sock->gen_sock.remote, remote, sizeof(sock_udp_ep_t));
+    }
+
+    sock->gen_sock.flags = flags;
+    sock->async_cb = NULL;
+
+    sock->next = udp_socket_list;
+    udp_socket_list = sock;
+
+    return 0;
+}
+
+int sock_udp_send(sock_udp_t *sock, const void *data, size_t len, const sock_udp_ep_t *remote) {
+    OpenQueueEntry_t *pkt;
+
+    if (sock == NULL && remote == NULL) {
+        return -EINVAL;
+    }
+
+    if (data == NULL && len != 0) {
+        return -EINVAL;
+    }
+
+    if ((pkt = openqueue_getFreePacketBuffer(COMPONENT_SOCK_TO_UDP)) == NULL) {
+        return -ENOMEM;
+    }
+
+    if (remote != NULL) {
+        if (remote->port == 0) {
+            return -EINVAL;
+        }
+        if (_sock_valid_af(remote->family) == FALSE) {
+            return -EAFNOSUPPORT;
+        }
+        if (_sock_valid_addr((sock_ip_ep_t *) remote) == FALSE) {
+            return -EINVAL;
+        }
+
+        pkt->l3_destinationAdd.type = ADDR_128B;
+        memcpy(&pkt->l3_destinationAdd.addr_128b, &remote->addr, LENGTH_ADDR128b);
+
+        pkt->l4_destination_port = remote->port;
+
+        if(sock != NULL){
+            pkt->l4_sourcePortORicmpv6Type = sock->gen_sock.local.port;
+        } else {
+            pkt->l4_sourcePortORicmpv6Type = openrandom_get16b();
+        }
+
+    } else if (sock != NULL) {
+        pkt->l3_destinationAdd.type = ADDR_128B;
+        memcpy(&pkt->l3_destinationAdd.addr_128b, &sock->gen_sock.remote.addr, LENGTH_ADDR128b);
+
+        pkt->l4_sourcePortORicmpv6Type = sock->gen_sock.local.port;
+        pkt->l4_destination_port = sock->gen_sock.remote.port;
+    } else if (sock == NULL) {
+        return -EINVAL;
+    }
+
+    open_addr_t local;
+    _sock_get_local_addr(&local);
+    memcpy(&pkt->l3_sourceAdd, &local, sizeof(open_addr_t));
+
+    pkt->owner = COMPONENT_SOCK_TO_UDP;
+    pkt->creator = COMPONENT_SOCK_TO_UDP;
+
+    packetfunctions_reserveHeaderSize(pkt, len);
+    memcpy(pkt->payload, data, len);
+
+    scheduler_push_task(_sock_transmit_internal, TASKPRIO_UDP);
+
+    pkt->l4_payload = pkt->payload;
+    pkt->l4_length = pkt->length;
+
+    return len;
+}
+
+void sock_udp_close(sock_udp_t *sock) {
+
+}
+
+int sock_udp_get_local(sock_udp_t *sock, sock_udp_ep_t *ep) {
+    return 0;
+}
+
+int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep) {
+    return 0;
+}
+
+int sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len, uint32_t timeout, sock_udp_ep_t *remote) {
+    uint16_t bytes_to_copy;
+    sock_udp_ep_t ep;
+
+    if (sock->txrx == NULL) {
+        return -EINVAL;
+    }
+
+    if (max_len >= sock->txrx->l4_length) {
+        bytes_to_copy = sock->txrx->l4_length;
+    } else {
+        bytes_to_copy = max_len;
+    }
+
+    if (remote != NULL){
+        ep.family = AF_INET6;
+        ep.port = sock->txrx->l4_sourcePortORicmpv6Type;
+        memcpy(&ep.addr, sock->txrx->l3_sourceAdd.addr_128b, LENGTH_ADDR128b);
+        memcpy(remote, &ep, sizeof(sock_udp_ep_t));
+    }
+
+    memset(data, 0, max_len);
+    memcpy(data, sock->txrx->l4_payload, bytes_to_copy);
+
+    openqueue_freePacketBuffer(sock->txrx);
+
+    return bytes_to_copy;
+}
+
+void sock_receive_internal(void) {
+    OpenQueueEntry_t *pkt;
+    sock_udp_t *current;
+
+    pkt = openqueue_getPacketByComponent(COMPONENT_UDP_TO_SOCK);
+
+    if (pkt == NULL) {
+        openserial_printf("found nothing\n");
+        return;
+    }
+
+    current = udp_socket_list;
+    while (current != NULL) {
+        if (current->gen_sock.local.port == pkt->l4_destination_port &&
+            current->async_cb != NULL &&
+            idmanager_isMyAddress(&pkt->l3_destinationAdd)) {
+
+            current->txrx = pkt;
+            current->async_cb(current, SOCK_ASYNC_MSG_RECV, NULL);
+            break;
+        }
+        current = current->next;
+    }
+
+    if (current == NULL) {
+        openqueue_freePacketBuffer(pkt);
+        openserial_printf("no associated socket found\n");
+    }
+}
+
+//============================= private =======================================
+
+void _sock_transmit_internal(void) {
+    OpenQueueEntry_t *pkt;
+
+    pkt = openqueue_getPacketByComponent(COMPONENT_SOCK_TO_UDP);
+
+    if (pkt == NULL) {
+        openserial_printf("found nothing\n");
+        return;
+    }
+
+    udp_transmit(pkt);
+}
+
+static bool _sock_valid_af(uint8_t af) {
+    if (af == AF_INET6) {
+        return TRUE;
+    } else {
+        return FALSE;
+    }
+}
+
+
+static void _sock_get_local_addr(open_addr_t *local) {
+    local->type = ADDR_128B;
+
+    open_addr_t *prefix_addr = idmanager_getMyID(ADDR_PREFIX);
+    memcpy(local->addr_128b, prefix_addr->prefix, 8);
+
+    open_addr_t *id64b_addr = idmanager_getMyID(ADDR_64B);
+    memcpy(local->addr_128b + 8, id64b_addr->addr_64b, 8);
+}
+
+static bool _sock_valid_addr(sock_ip_ep_t *ep) {
+    uint8_t zero_count;
+
+    const uint8_t *p = (uint8_t * ) & ep->addr;
+
+    zero_count = 0;
+    for (uint8_t i = 0; i < sizeof(ep->addr); i++) {
+        if (p[i] == 0) {
+            zero_count++;
+        }
+    }
+
+    if (zero_count == 16) {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+
+#endif

--- a/openstack/04-TRAN/sock.c
+++ b/openstack/04-TRAN/sock.c
@@ -31,6 +31,12 @@ void _sock_transmit_internal(void);
 
 //============================= public ========================================
 
+void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *cb_arg)
+{
+    sock->async_cb = cb;
+    sock->async_cb_arg = cb_arg;
+}
+
 void sock_udp_init(void) {
     udp_socket_list = NULL;
 }

--- a/openstack/04-TRAN/sock.h
+++ b/openstack/04-TRAN/sock.h
@@ -1,0 +1,53 @@
+#ifndef OPENWSN_SOCK_H
+#define OPENWSN_SOCK_H
+
+#include "opendefs.h"
+#include "sock_types.h"
+
+/**
+ *  @brief  Type for a UDP endpoint 
+ */
+typedef struct _sock_tl_ep sock_udp_ep_t;
+
+/**
+ * @brief   Type for a UDP sock object
+ */
+typedef struct sock_udp sock_udp_t;
+
+/**
+ * @brief   Initialize the internal UDP socket structures
+ */
+void sock_udp_init(void);
+
+/**
+ * @brief   Creates a new UDP sock object
+ */
+int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local, const sock_udp_ep_t *remote, uint16_t flags);
+
+/**
+ * @brief   Sends a UDP message to remote end point
+ */
+int sock_udp_send(sock_udp_t *sock, const void *data, size_t len, const sock_udp_ep_t *remote);
+
+/**
+ * @brief   Closes a UDP sock object
+ */
+void sock_udp_close(sock_udp_t *sock);
+
+/**
+ * @brief   Gets the local end point of a UDP sock object
+ */
+int sock_udp_get_local(sock_udp_t *sock, sock_udp_ep_t *ep);
+
+/**
+ * @brief   Gets the remote end point of a UDP sock object
+ */
+int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
+
+/**
+ * @brief   Receives a UDP message from a remote end point
+ */
+int sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len, uint32_t timeout, sock_udp_ep_t *remote);
+
+
+#endif /* OPENWSN_SOCK_H */

--- a/openstack/04-TRAN/sock.h
+++ b/openstack/04-TRAN/sock.h
@@ -2,7 +2,19 @@
 #define OPENWSN_SOCK_H
 
 #include "opendefs.h"
-#include "sock_types.h"
+#include "async_types.h"
+
+/**
+ * @brief   A Common IP-based transport layer endpoint
+ */
+struct _sock_tl_ep {
+    int family;
+    union {
+        uint8_t ipv6[16];
+    } addr;
+    uint16_t netif;
+    uint16_t port;
+};
 
 /**
  *  @brief  Type for a UDP endpoint 
@@ -49,5 +61,6 @@ int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
  */
 int sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len, uint32_t timeout, sock_udp_ep_t *remote);
 
+#include "sock_types.h"
 
 #endif /* OPENWSN_SOCK_H */

--- a/openstack/04-TRAN/sock_internal.h
+++ b/openstack/04-TRAN/sock_internal.h
@@ -1,0 +1,9 @@
+#ifndef OPENWSN_SOCK_INTERNAL_H
+#define OPENWSN_SOCK_INTERNAL_H
+
+#include "opendefs.h"
+
+void sock_receive_internal(void);
+
+
+#endif /* OPENWSN_SOCK_INTERNAL_H */

--- a/openstack/04-TRAN/sock_internal.h
+++ b/openstack/04-TRAN/sock_internal.h
@@ -5,5 +5,6 @@
 
 void sock_receive_internal(void);
 
+void sock_sendone_internal(OpenQueueEntry_t *msg, owerror_t error);
 
 #endif /* OPENWSN_SOCK_INTERNAL_H */

--- a/openstack/04-TRAN/sock_types.h
+++ b/openstack/04-TRAN/sock_types.h
@@ -1,25 +1,12 @@
-#ifndef OPENWSN_SOCK_INTERNAL_H
-#define OPENWSN_SOCK_INTERNAL_H
+#ifndef SOCK_TYPES_H
+#define SOCK_TYPES_H
 
-#include "async_types.h"
-
-/**
- * @brief   A Common IP-based transport layer endpoint
- */
-struct _sock_tl_ep {
-    int family;
-    union {
-        uint8_t ipv6[16];
-    } addr;
-    uint16_t port;
-};
-
-typedef struct _sock_tl_ep sock_ip_ep_t;   /**< An end point for a UDP sock object */
+#include "sock.h"
 
 struct _socket {
-    sock_ip_ep_t local;         /**< local end-point */
-    sock_ip_ep_t remote;        /**< remote end-point */
-    uint16_t flags;                   /**< option flags */
+    sock_udp_ep_t local;         /**< local end-point */
+    sock_udp_ep_t remote;        /**< remote end-point */
+    uint16_t flags;              /**< option flags */
 };
 
 typedef struct _socket socket_t;
@@ -32,4 +19,4 @@ struct sock_udp {
     struct sock_udp *next;
 };
 
-#endif /* OPENWSN_SOCK_INTERNAL_H */
+#endif /* SOCK_TYPES_H */

--- a/openstack/04-TRAN/sock_types.h
+++ b/openstack/04-TRAN/sock_types.h
@@ -1,0 +1,35 @@
+#ifndef OPENWSN_SOCK_INTERNAL_H
+#define OPENWSN_SOCK_INTERNAL_H
+
+#include "async_types.h"
+
+/**
+ * @brief   A Common IP-based transport layer endpoint
+ */
+struct _sock_tl_ep {
+    int family;
+    union {
+        uint8_t ipv6[16];
+    } addr;
+    uint16_t port;
+};
+
+typedef struct _sock_tl_ep sock_ip_ep_t;   /**< An end point for a UDP sock object */
+
+struct _socket {
+    sock_ip_ep_t local;         /**< local end-point */
+    sock_ip_ep_t remote;        /**< remote end-point */
+    uint16_t flags;                   /**< option flags */
+};
+
+typedef struct _socket socket_t;
+
+struct sock_udp {
+    socket_t gen_sock;                /**< Generic socket */
+    sock_udp_cb_t async_cb;           /**< asynchronous callback */
+    OpenQueueEntry_t* txrx;
+    void* async_cb_arg;
+    struct sock_udp *next;
+};
+
+#endif /* OPENWSN_SOCK_INTERNAL_H */

--- a/openstack/04-TRAN/udp.c
+++ b/openstack/04-TRAN/udp.c
@@ -2,273 +2,52 @@
 
 #if defined(OPENWSN_UDP_C)
 
-#include "opendefs.h"
-#include "udp.h"
+#include "sock_internal.h"
 #include "openserial.h"
 #include "packetfunctions.h"
-#include "forwarding.h"
+#include "scheduler.h"
+#include "udp.h"
 #include "openqueue.h"
+#include "forwarding.h"
 
 //=========================== variables =======================================
 
-openudp_vars_t openudp_vars;
-
 //=========================== prototypes ======================================
-
-static void openudp_sendDone_default_handler(OpenQueueEntry_t *msg, owerror_t error);
-
-static void openudp_receive_default_handler(OpenQueueEntry_t *msg);
 
 //=========================== public ==========================================
 
-void openudp_init(void) {
-    // initialize the resource linked list
-    openudp_vars.resources = NULL;
+void udp_sendDone(OpenQueueEntry_t *msg, owerror_t error) {
+    openqueue_freePacketBuffer(msg);
 }
 
-void openudp_register(udp_resource_desc_t *desc) {
-    // chain the new resource to head of resource list
-    desc->next = openudp_vars.resources;
-    openudp_vars.resources = desc;
-}
+void udp_receive(OpenQueueEntry_t *msg) {
 
-owerror_t openudp_send(OpenQueueEntry_t *msg) {
-    uint8_t *checksum_position;
-    msg->owner = COMPONENT_OPENUDP;
-    msg->l4_protocol = IANA_UDP;
-    msg->l4_payload = msg->payload;
+    msg->owner = COMPONENT_UDP_TO_SOCK;
+    msg->l4_sourcePortORicmpv6Type = packetfunctions_ntohs((uint8_t * ) & (((udp_ht *) (msg->payload))->source_port));
+    msg->l4_destination_port = packetfunctions_ntohs((uint8_t * ) & (((udp_ht *) (msg->payload))->dest_port));
+
+    // verify checksum
+
+    scheduler_push_task(sock_receive_internal, TASKPRIO_UDP);
+
+    packetfunctions_tossHeader(msg, sizeof(udp_ht));
     msg->l4_length = msg->length;
-
-    msg->l4_protocol_compressed = FALSE; // by default
-    uint8_t compType = NHC_UDP_PORTS_INLINE;
-
-    //check if the header can be compressed.
-    if (msg->l4_destination_port >= 0xf000 && msg->l4_destination_port < 0xf100) {
-        // destination can be compressed 8 bit
-        msg->l4_protocol_compressed = TRUE;
-        compType = NHC_UDP_PORTS_16S_8D;
-        //check now if both can still be more compressed 4b each
-        if (
-                msg->l4_destination_port >= 0xf0b0 &&
-                msg->l4_destination_port <= 0xf0bf &&
-                msg->l4_sourcePortORicmpv6Type >= 0xf0b0 &&
-                msg->l4_sourcePortORicmpv6Type <= 0xf0bf
-                ) {
-            //can be fully compressed
-            compType = NHC_UDP_PORTS_4S_4D;
-        }
-    } else {
-        //check source now
-        if (msg->l4_sourcePortORicmpv6Type >= 0xf000 && msg->l4_sourcePortORicmpv6Type < 0xf100) {
-            //source can be compressed -> 8bit
-            msg->l4_protocol_compressed = TRUE;
-            compType = NHC_UDP_PORTS_8S_16D;
-        }
-    }
-
-    // fill in the header in the packet
-    if (msg->l4_protocol_compressed) {
-
-        // add checksum space in the packet.
-        if (packetfunctions_reserveHeader(&msg, 2) == E_FAIL) {
-            return E_FAIL;
-        }
-        //keep position and calculatre checksum at the end.
-        checksum_position = &msg->payload[0];
-
-        //length is always omitted
-        /*
-         RFC6282 -> The UDP Length field
-                   MUST always be elided and is inferred from lower layers using the
-                   6LoWPAN Fragmentation header or the IEEE 802.15.4 header.
-        */
-
-        switch (compType) {
-            case NHC_UDP_PORTS_INLINE:
-                // error this is not possible.
-                break;
-            case NHC_UDP_PORTS_16S_8D:
-                // dest port:   0xf0  +  8 bits in-line
-                // source port:         16 bits in-line
-                if (packetfunctions_reserveHeader(&msg, 1) == E_FAIL) {
-                    return E_FAIL;
-                }
-                msg->payload[0] = (uint8_t)(msg->l4_destination_port & 0x00ff);
-
-                if (packetfunctions_reserveHeader(&msg, 2) == E_FAIL) {
-                    return E_FAIL;
-                }
-                packetfunctions_htons(msg->l4_sourcePortORicmpv6Type, &(msg->payload[0]));
-
-                //write proper LOWPAN_NHC
-                if (packetfunctions_reserveHeader(&msg, 1) == E_FAIL) {
-                    return E_FAIL;
-                }
-                msg->payload[0] = NHC_UDP_ID | NHC_UDP_PORTS_16S_8D;
-                break;
-            case NHC_UDP_PORTS_8S_16D:
-                // dest port:   0xf0  + 16 bits in-line
-                // source port: 0xf0  +  8 bits in-line
-                if (packetfunctions_reserveHeader(&msg, 2) == E_FAIL) {
-                    return E_FAIL;
-                }
-                packetfunctions_htons(msg->l4_destination_port, &(msg->payload[0]));
-
-                if (packetfunctions_reserveHeader(&msg, 1) == E_FAIL) {
-                    return E_FAIL;
-                }
-                msg->payload[0] = (uint8_t)(msg->l4_sourcePortORicmpv6Type & 0x00ff);
-
-                //write proper LOWPAN_NHC
-                if (packetfunctions_reserveHeader(&msg, 1) == E_FAIL) {
-                    return E_FAIL;
-                }
-                msg->payload[0] = NHC_UDP_ID | NHC_UDP_PORTS_8S_16D;
-                break;
-            case NHC_UDP_PORTS_4S_4D:
-                // source port: 0xf0b +  4 bits in-line (high 4)
-                // dest port:   0xf0b +  4 bits in-line  (low 4)
-                if (packetfunctions_reserveHeader(&msg, 1) == E_FAIL) {
-                    return E_FAIL;
-                }
-                msg->payload[0] = (msg->l4_sourcePortORicmpv6Type & 0x000f) << 4;
-                msg->payload[0] |= (msg->l4_destination_port & 0x000f);
-
-                //write proper LOWPAN_NHC
-                if (packetfunctions_reserveHeader(&msg, 1) == E_FAIL) {
-                    return E_FAIL;
-                }
-                msg->payload[0] = NHC_UDP_ID | NHC_UDP_PORTS_4S_4D;
-                break;
-        }
-
-        //after filling the packet we calculate the checksum
-        packetfunctions_calculateChecksum(msg, checksum_position);
-
-    } else {
-        if (packetfunctions_reserveHeader(&msg, sizeof(udp_ht)) == E_FAIL) {
-            return E_FAIL;
-        }
-        packetfunctions_htons(msg->l4_sourcePortORicmpv6Type, &(msg->payload[0]));
-        packetfunctions_htons(msg->l4_destination_port, &(msg->payload[2]));
-        //TODO check this as the lenght MUST be ommited.
-        packetfunctions_htons(msg->length, &(msg->payload[4]));
-        packetfunctions_calculateChecksum(msg, (uint8_t * ) & (((udp_ht *) msg->payload)->checksum));
-    }
-    return forwarding_send(msg);
+    msg->l4_payload = msg->payload;
 }
 
-void openudp_sendDone(OpenQueueEntry_t *msg, owerror_t error) {
-    udp_resource_desc_t *resource;
-    udp_callbackSendDone_cbt udp_send_done_callback_ptr = NULL;
+void udp_transmit(OpenQueueEntry_t *msg) {
+    msg->l4_protocol_compressed = FALSE;
+    msg->l4_protocol = IANA_UDP;
 
-    msg->owner = COMPONENT_OPENUDP;
+    packetfunctions_reserveHeaderSize(msg, sizeof(udp_ht));
+    packetfunctions_htons(msg->l4_sourcePortORicmpv6Type, &(msg->payload[0]));
+    packetfunctions_htons(msg->l4_destination_port, &(msg->payload[2]));
+    packetfunctions_htons(msg->length, &(msg->payload[4]));
+    packetfunctions_calculateChecksum(msg, (uint8_t * ) & (((udp_ht *) msg->payload)->checksum));
 
-    // iterate list of registered resources
-    resource = openudp_vars.resources;
-    while (NULL != resource) {
-        if (resource->port == msg->l4_sourcePortORicmpv6Type) {
-            // there is a registration for this port, either forward the send completion or simply release the message
-            udp_send_done_callback_ptr = (resource->callbackSendDone == NULL) ? openudp_sendDone_default_handler
-                                                                              : resource->callbackSendDone;
-            break;
-        }
-        resource = resource->next;
-    }
-
-    if (udp_send_done_callback_ptr == NULL) {
-        LOG_ERROR(COMPONENT_OPENUDP, ERR_UNSUPPORTED_PORT_NUMBER,
-                  (errorparameter_t) msg->l4_sourcePortORicmpv6Type,
-                  (errorparameter_t) 5);
+    if (forwarding_send(msg) == E_FAIL) {
         openqueue_freePacketBuffer(msg);
-        return;
     }
-
-    // handle send completion
-    udp_send_done_callback_ptr(msg, error);
-}
-
-void openudp_receive(OpenQueueEntry_t *msg) {
-    uint8_t temp_8b;
-    udp_resource_desc_t *resource;
-    udp_callbackReceive_cbt udp_receive_done_callback_ptr = NULL;
-
-    msg->owner = COMPONENT_OPENUDP;
-
-    if (msg->l4_protocol_compressed == TRUE) {
-        // get the UDP header encoding byte
-        temp_8b = *((uint8_t * )(msg->payload));
-        packetfunctions_tossHeader(&msg, sizeof(temp_8b));
-        switch (temp_8b & NHC_UDP_PORTS_MASK) {
-            case NHC_UDP_PORTS_INLINE:
-                // source port:         16 bits in-line
-                // dest port:           16 bits in-line
-                msg->l4_sourcePortORicmpv6Type = msg->payload[0] * 256 + msg->payload[1];
-                msg->l4_destination_port = msg->payload[2] * 256 + msg->payload[3];
-                packetfunctions_tossHeader(&msg, 2 + 2);
-                break;
-            case NHC_UDP_PORTS_16S_8D:
-                // source port:         16 bits in-line
-                // dest port:   0xf0  +  8 bits in-line
-                msg->l4_sourcePortORicmpv6Type = msg->payload[0] * 256 + msg->payload[1];
-                msg->l4_destination_port = 0xf000 + msg->payload[2];
-                packetfunctions_tossHeader(&msg, 2 + 1);
-                break;
-            case NHC_UDP_PORTS_8S_16D:
-                // source port: 0xf0  +  8 bits in-line
-                // dest port:   0xf0  +  8 bits in-line
-                msg->l4_sourcePortORicmpv6Type = 0xf000 + msg->payload[0];
-                msg->l4_destination_port = msg->payload[1] * 256 + msg->payload[2];
-                packetfunctions_tossHeader(&msg, 1 + 2);
-                break;
-            case NHC_UDP_PORTS_4S_4D:
-                // source port: 0xf0b +  4 bits in-line
-                // dest port:   0xf0b +  4 bits in-line
-                msg->l4_sourcePortORicmpv6Type = 0xf0b0 + ((msg->payload[0] >> 4) & 0x0f);
-                msg->l4_destination_port = 0xf0b0 + ((msg->payload[0] >> 0) & 0x0f);
-                packetfunctions_tossHeader(&msg, 1);
-                break;
-        }
-    } else {
-        msg->l4_sourcePortORicmpv6Type = msg->payload[0] * 256 + msg->payload[1];
-        msg->l4_destination_port = msg->payload[2] * 256 + msg->payload[3];
-        packetfunctions_tossHeader(&msg, sizeof(udp_ht));
-    }
-
-    // iterate list of registered resources
-    resource = openudp_vars.resources;
-    while (NULL != resource) {
-        if (resource->port == msg->l4_destination_port) {
-            udp_receive_done_callback_ptr = (resource->callbackReceive == NULL) ? openudp_receive_default_handler
-                                                                                : resource->callbackReceive;
-            break;
-        }
-        resource = resource->next;
-    }
-
-    if (udp_receive_done_callback_ptr == NULL) {
-        LOG_ERROR(COMPONENT_OPENUDP, ERR_UNSUPPORTED_PORT_NUMBER,
-                  (errorparameter_t) msg->l4_destination_port,
-                  (errorparameter_t) 6);
-        openqueue_freePacketBuffer(msg);
-    } else {
-        // forward message to resource
-        udp_receive_done_callback_ptr(msg);
-    }
-}
-
-bool openudp_debugPrint(void) {
-    return FALSE;
-}
-
-//=========================== private =========================================
-
-static void openudp_sendDone_default_handler(OpenQueueEntry_t *msg, owerror_t error) {
-    openqueue_freePacketBuffer(msg);
-}
-
-static void openudp_receive_default_handler(OpenQueueEntry_t *msg) {
-    openqueue_freePacketBuffer(msg);
 }
 
 #endif /* OPENWSN_UDP_C */

--- a/openstack/04-TRAN/udp.c
+++ b/openstack/04-TRAN/udp.c
@@ -30,7 +30,7 @@ void udp_receive(OpenQueueEntry_t *msg) {
 
     scheduler_push_task(sock_receive_internal, TASKPRIO_UDP);
 
-    packetfunctions_tossHeader(msg, sizeof(udp_ht));
+    packetfunctions_tossHeader(&msg, sizeof(udp_ht));
     msg->l4_length = msg->length;
     msg->l4_payload = msg->payload;
 }
@@ -39,7 +39,7 @@ void udp_transmit(OpenQueueEntry_t *msg) {
     msg->l4_protocol_compressed = FALSE;
     msg->l4_protocol = IANA_UDP;
 
-    packetfunctions_reserveHeaderSize(msg, sizeof(udp_ht));
+    packetfunctions_reserveHeader(&msg, sizeof(udp_ht));
     packetfunctions_htons(msg->l4_sourcePortORicmpv6Type, &(msg->payload[0]));
     packetfunctions_htons(msg->l4_destination_port, &(msg->payload[2]));
     packetfunctions_htons(msg->length, &(msg->payload[4]));

--- a/openstack/04-TRAN/udp.c
+++ b/openstack/04-TRAN/udp.c
@@ -17,6 +17,8 @@
 //=========================== public ==========================================
 
 void udp_sendDone(OpenQueueEntry_t *msg, owerror_t error) {
+    msg->owner = COMPONENT_UDP;
+    sock_sendone_internal(msg, error);
     openqueue_freePacketBuffer(msg);
 }
 

--- a/openstack/04-TRAN/udp.h
+++ b/openstack/04-TRAN/udp.h
@@ -1,84 +1,25 @@
 #ifndef OPENWSN_UDP_H
 #define OPENWSN_UDP_H
 
-/**
-\addtogroup Transport
-\{
-\addtogroup Udp
-\{
-*/
+#include "opendefs.h"
 
-#include "config.h"
 //=========================== define ==========================================
-
-enum UDP_enums {
-    UDP_ID = 3,
-    UDP_CHECKSUM = 2,
-    UDP_PORTS = 0,
-};
-
-enum UDP_ID_enums {
-    UDP_ID_DEFAULT = 0x1E,
-};
-
-enum UDP_CHECKSUM_enums {
-    UDP_CHECKSUM_INLINE = 0,
-    UDP_CHECKSUM_ELIDED = 1,
-};
-
-enum UDP_PORTS_enums {
-    UDP_PORTS_16b_SRC_16b_DEST_INLINE = 0,
-    UDP_PORTS_16b_SRC_8b_DEST_INLINE = 1,
-    UDP_PORTS_8b_SRC_16b_DEST_INLINE = 2,
-    UDP_PORTS_4b_SRC_4b_DEST_INLINE = 3,
-};
 
 //=========================== typedef =========================================
 
-typedef struct {
-    uint16_t port_src;
-    uint16_t port_dest;
-    uint16_t length; // this should not be here. See RFC6282 section 4.3.3.
+typedef struct udp_header {
+    uint16_t source_port;
+    uint16_t dest_port;
+    uint16_t length;
     uint16_t checksum;
 } udp_ht;
 
-
-typedef void (*udp_callbackReceive_cbt)(OpenQueueEntry_t *msg);
-
-typedef void (*udp_callbackSendDone_cbt)(OpenQueueEntry_t *msg, owerror_t error);
-
-typedef struct udp_resource_desc_t udp_resource_desc_t;
-
-struct udp_resource_desc_t {
-    uint16_t port;             ///< UDP port that is associated with the resource
-    udp_callbackReceive_cbt callbackReceive;  ///< receive callback, if NULL, all message received for port will be discarded
-    udp_callbackSendDone_cbt callbackSendDone; ///< send completion callback, if NULL, the associated message will be release without notification
-    udp_resource_desc_t *next;
-};
-
-//=========================== variables =======================================
-
-typedef struct {
-    udp_resource_desc_t *resources;
-} openudp_vars_t;
-
 //=========================== prototypes ======================================
 
-void openudp_init(void);
+void udp_sendDone(OpenQueueEntry_t *msg, owerror_t);
 
-void openudp_register(udp_resource_desc_t *desc);
+void udp_receive(OpenQueueEntry_t *msg);
 
-owerror_t openudp_send(OpenQueueEntry_t *msg);
-
-void openudp_sendDone(OpenQueueEntry_t *msg, owerror_t error);
-
-void openudp_receive(OpenQueueEntry_t *msg);
-
-bool openudp_debugPrint(void);
-
-/**
-\}
-\}
-*/
+void udp_transmit(OpenQueueEntry_t *msg);
 
 #endif /* OPENWSN_UDP_H */

--- a/openstack/SConscript
+++ b/openstack/SConscript
@@ -29,6 +29,8 @@ sources_c = [
     os.path.join('03b-IPv6','icmpv6rpl.c'),
     #=== 04-TRAN
     os.path.join('04-TRAN','udp.c'),
+    os.path.join('04-TRAN','sock.c'),
+    os.path.join('04-TRAN','async.c'),
     #=== cross-layers
     os.path.join('cross-layers','idmanager.c'),
     os.path.join('cross-layers','openqueue.c'),
@@ -59,6 +61,11 @@ sources_h = [
     os.path.join('03b-IPv6','icmpv6rpl.h'),
     #=== 04-TRAN
     os.path.join('04-TRAN','udp.h'),
+    os.path.join('04-TRAN','sock.h'),
+    os.path.join('04-TRAN','async.h'),
+    os.path.join('04-TRAN','sock_types.h'),
+    os.path.join('04-TRAN','sock_internal.h'),
+    os.path.join('04-TRAN','async_types.h'),
     #=== cross-layers
     os.path.join('cross-layers','idmanager.h'),
     os.path.join('cross-layers','openqueue.h'),

--- a/openstack/cross-layers/idmanager.c
+++ b/openstack/cross-layers/idmanager.c
@@ -33,7 +33,7 @@ void idmanager_init(void) {
     idmanager_vars.myPANID.type = ADDR_PANID;
 #ifdef PANID_DEFINED
     idmanager_vars.myPANID.panid[0] = PANID_DEFINED & 0x00ff;
-    idmanager_vars.myPANID.panid[1] =(PANID_DEFINED & 0xff00)>>8;
+    idmanager_vars.myPANID.panid[1] = (PANID_DEFINED & 0xff00)>>8;
 #else
     idmanager_vars.myPANID.panid[0] = 0xca;
     idmanager_vars.myPANID.panid[1] = 0xfe;
@@ -41,14 +41,14 @@ void idmanager_init(void) {
     // myPrefix
     idmanager_vars.myPrefix.type = ADDR_PREFIX;
 #ifdef DAGROOT
-    idmanager_vars.myPrefix.prefix[0]  = 0xbb;
-    idmanager_vars.myPrefix.prefix[1]  = 0xbb;
-    idmanager_vars.myPrefix.prefix[2]  = 0x00;
-    idmanager_vars.myPrefix.prefix[3]  = 0x00;
-    idmanager_vars.myPrefix.prefix[4]  = 0x00;
-    idmanager_vars.myPrefix.prefix[5]  = 0x00;
-    idmanager_vars.myPrefix.prefix[6]  = 0x00;
-    idmanager_vars.myPrefix.prefix[7]  = 0x00;
+    idmanager_vars.myPrefix.prefix[0] = 0xbb;
+    idmanager_vars.myPrefix.prefix[1] = 0xbb;
+    idmanager_vars.myPrefix.prefix[2] = 0x00;
+    idmanager_vars.myPrefix.prefix[3] = 0x00;
+    idmanager_vars.myPrefix.prefix[4] = 0x00;
+    idmanager_vars.myPrefix.prefix[5] = 0x00;
+    idmanager_vars.myPrefix.prefix[6] = 0x00;
+    idmanager_vars.myPrefix.prefix[7] = 0x00;
 #else
     // set prefix to link-local
     idmanager_vars.myPrefix.prefix[0] = 0xfe;
@@ -100,6 +100,7 @@ bool idmanager_getIsSlotSkip(void) {
 
 open_addr_t* idmanager_getMyID(uint8_t type) {
     open_addr_t *res;
+
     INTERRUPT_DECLARATION();
     DISABLE_INTERRUPTS();
     switch (type) {
@@ -116,7 +117,7 @@ open_addr_t* idmanager_getMyID(uint8_t type) {
             res = &idmanager_vars.myPrefix;
             break;
         case ADDR_128B:
-            // you don't ask for my full address, rather for prefix, then 64b
+            // build full IPv6 address from prefix and 64b ID.
         default:
             LOG_CRITICAL(COMPONENT_IDMANAGER, ERR_WRONG_ADDR_TYPE, (errorparameter_t) type, (errorparameter_t) 0);
             res = NULL;
@@ -145,7 +146,8 @@ owerror_t idmanager_setMyID(open_addr_t *newID) {
         case ADDR_128B:
             //don't set 128b, but rather prefix and 64b
         default:
-            LOG_CRITICAL(COMPONENT_IDMANAGER, ERR_WRONG_ADDR_TYPE, (errorparameter_t) newID->type,
+            LOG_CRITICAL(COMPONENT_IDMANAGER, ERR_WRONG_ADDR_TYPE,
+                         (errorparameter_t) newID->type,
                          (errorparameter_t) 1);
             ENABLE_INTERRUPTS();
             return E_FAIL;
@@ -187,7 +189,9 @@ bool idmanager_isMyAddress(open_addr_t *addr) {
             ENABLE_INTERRUPTS();
             return res;
         default:
-            LOG_CRITICAL(COMPONENT_IDMANAGER, ERR_WRONG_ADDR_TYPE, (errorparameter_t) addr->type, (errorparameter_t) 2);
+            LOG_CRITICAL(COMPONENT_IDMANAGER, ERR_WRONG_ADDR_TYPE,
+                         (errorparameter_t) addr->type,
+                         (errorparameter_t) 2);
             ENABLE_INTERRUPTS();
             return FALSE;
     }
@@ -238,7 +242,11 @@ void idmanager_triggerAboutRoot(void) {
 
     // store prefix (bytes 1-8)
     myPrefix.type = ADDR_PREFIX;
-    memcpy(myPrefix.prefix, &input_buffer[1], sizeof(myPrefix.prefix));
+    memcpy(
+            myPrefix.prefix,
+            &input_buffer[1],
+            sizeof(myPrefix.prefix)
+    );
     idmanager_setMyID(&myPrefix);
 
     // indicate DODAGid to RPL

--- a/openstack/cross-layers/openqueue.c
+++ b/openstack/cross-layers/openqueue.c
@@ -435,6 +435,22 @@ void openqueue_updateNextHopPayload(open_addr_t *newNextHop) {
     ENABLE_INTERRUPTS();
 }
 
+OpenQueueEntry_t*  openqueue_getPacketByComponent(uint8_t component) {
+    uint8_t i;
+    INTERRUPT_DECLARATION();
+    DISABLE_INTERRUPTS();
+
+    for (i = 0; i < QUEUELENGTH; i++) {
+        if (openqueue_vars.queue[i].owner == component) {
+            ENABLE_INTERRUPTS();
+            return &openqueue_vars.queue[i];
+        }
+    }
+
+    ENABLE_INTERRUPTS();
+    return NULL;
+}
+
 OpenQueueEntry_t*  openqueue_macGetUnicastPacket(open_addr_t* toNeighbor){
     uint8_t i;
     INTERRUPT_DECLARATION();

--- a/openstack/cross-layers/openqueue.h
+++ b/openstack/cross-layers/openqueue.h
@@ -84,6 +84,9 @@ OpenQueueEntry_t* openqueue_macGetKaPacket(open_addr_t *toNeighbor);
 OpenQueueEntry_t* openqueue_macGetDIOPacket(void);
 
 OpenQueueEntry_t* openqueue_macGetUnicastPacket(open_addr_t *toNeighbor);
+
+// called by transport layer
+OpenQueueEntry_t* openqueue_getPacketByComponent(uint8_t component);
 /**
 \}
 \}

--- a/openstack/openstack.c
+++ b/openstack/openstack.c
@@ -34,7 +34,7 @@
 #include "icmpv6echo.h"
 #include "icmpv6rpl.h"
 //-- 04-TRAN
-#include "udp.h"
+#include "sock.h"
 
 //===== application-layer
 #include "openweb.h"
@@ -94,7 +94,7 @@ void openstack_init(void) {
     //-- 04-TRAN
 
 #if defined(OPENWSN_UDP_C)
-    openudp_init();
+    sock_udp_init();
 #endif
 
     //===== application-layer

--- a/openweb/opencoap/coap.c
+++ b/openweb/opencoap/coap.c
@@ -85,7 +85,6 @@ void coap_init(void) {
     coap_vars.desc.port = WKP_UDP_COAP;
     coap_vars.desc.callbackReceive = coap_receive;
     coap_vars.desc.callbackSendDone = coap_sendDone;
-    openudp_register(&coap_vars.desc);
 }
 
 /**
@@ -514,9 +513,6 @@ void coap_receive(OpenQueueEntry_t *msg) {
         return;
     }
 
-    if ((openudp_send(msg)) == E_FAIL) {
-        openqueue_freePacketBuffer(msg);
-    }
 }
 
 /**
@@ -766,7 +762,6 @@ owerror_t coap_send(
         return E_FAIL;
     }
 
-    return openudp_send(msg);
 }
 
 /**
@@ -1233,41 +1228,24 @@ void coap_forward_message(OpenQueueEntry_t *msg,
 
     // fill payload
     if (msg->length) {
-        if (packetfunctions_reserveHeader(&outgoingPacket, msg->length) == E_FAIL) {
-            goto fail;
-        }
+        packetfunctions_reserveHeader(&outgoingPacket, msg->length);
         memcpy(outgoingPacket->payload, msg->payload, msg->length);
-        if (packetfunctions_reserveHeader(&outgoingPacket, 1) == E_FAIL) {
-            goto fail;
-        }
+        packetfunctions_reserveHeader(&outgoingPacket, 1);
         outgoingPacket->payload[0] = COAP_PAYLOAD_MARKER;
     }
 
     // encode options
-    if (coap_options_encode(outgoingPacket, outgoingOptions, outgoingOptionsLen, COAP_OPTION_CLASS_ALL) == E_FAIL) {
-        goto fail;
-    }
+    coap_options_encode(outgoingPacket, outgoingOptions, outgoingOptionsLen, COAP_OPTION_CLASS_ALL);
 
     // encode CoAP header
-    if (coap_header_encode(outgoingPacket,
-                           header->Ver,
-                           header->T,
-                           header->TKL,
-                           header->Code,
-                           header->messageID,
-                           header->token) == E_FAIL) {
-        goto fail;
-    }
+    coap_header_encode(outgoingPacket,
+                       header->Ver,
+                       header->T,
+                       header->TKL,
+                       header->Code,
+                       header->messageID,
+                       header->token);
 
-    if ((openudp_send(outgoingPacket)) == E_FAIL) {
-        goto fail;
-    }
-
-    return;
-
-    fail:
-    openqueue_freePacketBuffer(outgoingPacket);
-    return;
 }
 
 #endif /* OPENWSN_COAP_C */

--- a/openweb/opencoap/coap.h
+++ b/openweb/opencoap/coap.h
@@ -210,7 +210,6 @@ typedef struct {
 //=========================== module variables ================================
 
 typedef struct {
-    udp_resource_desc_t desc;
     coap_resource_desc_t *resources;
     bool busySending;
     uint8_t delayCounter;

--- a/projects/python/SConscript.env
+++ b/projects/python/SConscript.env
@@ -1,11 +1,11 @@
-import os
-import sys
 import datetime
-import re
+import os
 import platform
-import sconsUtils
+import re
+import sys
 
 import distutils.sysconfig
+import sconsUtils
 
 Import('env')
 
@@ -23,55 +23,54 @@ buildEnv['BSP'] = buildEnv['board']
 # Define locations for Python headers and shared library. A cross-platform build
 # requires environment variables for these locations.
 isCrossBuild = False
-if os.name!='nt':
-    if platform.architecture()[0]=='64bit' and buildEnv['simhost']=='x86-linux':
+if os.name != 'nt':
+    if platform.architecture()[0] == '64bit' and buildEnv['simhost'] == 'x86-linux':
         # Search for a well-known file in the include directory tree to avoid 
         # hard-coding the intervening directories, which may refer to the build host
         # or Python version. For example, on the author's system, the file is in the
         # 'i386-linux-gnu/python2.7' directory.
         isCrossBuild = True
-        pathnames    = sconsUtils.findPattern('Python.h',
-                                              '{0}/include'.format(buildEnv['simhostpy']))
+        pathnames = sconsUtils.findPattern('Python.h', '{0}/include'.format(buildEnv['simhostpy']))
         if pathnames:
             pathname = pathnames[0]
         else:
             raise SystemError("Can't find python header in 'include' directory below provided simhostpy")
-        pythonInc    = os.path.dirname(pathname)
-        pythonLib    = '{0}/lib'.format(buildEnv['simhostpy'])
-        
+        pythonInc = os.path.dirname(pathname)
+        pythonLib = '{0}/lib'.format(buildEnv['simhostpy'])
+
     elif buildEnv['simhost'].endswith('-windows'):
         isCrossBuild = True
-        pythonInc    = buildEnv['simhostpy']
-        pythonLib    = buildEnv['simhostpy']
-    
+        pythonInc = buildEnv['simhostpy']
+        pythonLib = buildEnv['simhostpy']
+
 if not isCrossBuild:
     pythonInc = distutils.sysconfig.get_python_inc()
-    pythonLib = distutils.sysconfig.PREFIX+"/lib"
+    pythonLib = distutils.sysconfig.PREFIX + "/lib"
     if not sys.platform.startswith('darwin'):
-        pythonLib+="s"
-    
+        pythonLib += "s"
+
 # update C include path
 buildEnv.Append(
-    CPPPATH = [
+    CPPPATH=[
         pythonInc,
         # inc
-        os.path.join('#','build','python_gcc','inc'),
+        os.path.join('#', 'build', 'python_gcc', 'inc'),
         # bsp
-        os.path.join('#','build','python_gcc','bsp','boards'),
-        os.path.join('#','build','python_gcc','bsp','boards','python'),
+        os.path.join('#', 'build', 'python_gcc', 'bsp', 'boards'),
+        os.path.join('#', 'build', 'python_gcc', 'bsp', 'boards', 'python'),
         # drivers
-        os.path.join('#','build','python_gcc','drivers','common'),
-        os.path.join('#','build','python_gcc','drivers','common','crypto'),
+        os.path.join('#', 'build', 'python_gcc', 'drivers', 'common'),
+        os.path.join('#', 'build', 'python_gcc', 'drivers', 'common', 'crypto'),
         # kernel
-        os.path.join('#','build','python_gcc','kernel'),
+        os.path.join('#', 'build', 'python_gcc', 'kernel'),
         # openstack
-        os.path.join('#','build','python_gcc','openstack'),
-        os.path.join('#','build','python_gcc','openstack','02a-MAClow'),
-        os.path.join('#','build','python_gcc','openstack','02b-MAChigh'),
-        os.path.join('#','build','python_gcc','openstack','03a-IPHC'),
-        os.path.join('#','build','python_gcc','openstack','03b-IPv6'),
-        os.path.join('#','build','python_gcc','openstack','04-TRAN'),
-        os.path.join('#','build','python_gcc','openstack','cross-layers'),
+        os.path.join('#', 'build', 'python_gcc', 'openstack'),
+        os.path.join('#', 'build', 'python_gcc', 'openstack', '02a-MAClow'),
+        os.path.join('#', 'build', 'python_gcc', 'openstack', '02b-MAChigh'),
+        os.path.join('#', 'build', 'python_gcc', 'openstack', '03a-IPHC'),
+        os.path.join('#', 'build', 'python_gcc', 'openstack', '03b-IPv6'),
+        os.path.join('#', 'build', 'python_gcc', 'openstack', '04-TRAN'),
+        os.path.join('#', 'build', 'python_gcc', 'openstack', 'cross-layers'),
         # openweb
         os.path.join('#','build','python_gcc','openweb'),
         os.path.join('#','build','python_gcc','openweb','opencoap'),
@@ -95,35 +94,37 @@ buildEnv.Append(
 
 # update library include path
 buildEnv.Append(
-    LIBPATH = [pythonLib],
+    LIBPATH=[pythonLib],
 )
 
-#============================ objectify functions =============================
 
-#===== ObjectifiedFilename
+# ============================ objectify functions =============================
 
-def ObjectifiedFilename(env,source):
-    dir       = os.path.split(source)[0]
-    file      = os.path.split(source)[1]
-    filebase  = file.split('.')[0]
-    fileext   = file.split('.')[1]
-    return os.path.join(dir,'{0}_obj.{1}'.format(filebase,fileext))
+# ===== ObjectifiedFilename
 
-buildEnv.AddMethod(ObjectifiedFilename, 'ObjectifiedFilename')
+def objectified_filename(env, source):
+    directory = os.path.split(source)[0]
+    filename = os.path.split(source)[1]
+    file_base = filename.split('.')[0]
+    file_ext = filename.split('.')[1]
+    return os.path.join(directory, '{0}_obj.{1}'.format(file_base, file_ext))
 
-#===== Objectify
 
-varsToChange = [
-    #===== drivers
+buildEnv.AddMethod(objectified_filename, 'ObjectifiedFilename')
+
+# ===== Objectify
+
+vars_to_change = [
+    # ===== drivers
     'openserial_vars',
     'opentimers_vars',
-    #===== core
+    # ===== core
     'scheduler_vars',
     'scheduler_dbg',
     'openqueue_vars',
     'random_vars',
     'idmanager_vars',
-    #===== stack
+    # ===== stack
     # 02a-MAClow
     'adaptive_sync_vars',
     'ieee154e_vars',
@@ -141,16 +142,13 @@ varsToChange = [
     # 03b-IPv6
     'icmpv6echo_vars',
     'icmpv6rpl_vars',
-    #===== applications
-    #+++++ UDP
-    #- debug
-    #- common
-    'udpstorm_vars',
-    'openudp_vars',
-    #+++++ CoAP
+    # ===== applications
+    # +++++ UDP
+    # - debug
+    # +++++ CoAP
     'coap_vars',
-    #- debug
-    #- common
+    # - debug
+    # - common
     'r6t_vars',
     'rinfo_vars',
     'rrt_vars',
@@ -162,14 +160,14 @@ varsToChange = [
     'csensors_vars',
     'cstorm_vars',
     'cwellknown_vars',
-    'uecho_vars',
     'uinject_vars',
     'userialbridge_vars',
 ]
 
-returnTypes = [
+return_types = [
     'int',
     'int8_t',
+    'size_t',
     'void',
     'owerror_t',
     'uint8_t',
@@ -196,8 +194,8 @@ returnTypes = [
     'm_keyDescriptor*',
 ]
 
-callbackFunctionsToChange = [
-    #===== bsp
+cb_functions_to_change = [
+    # ===== bsp
     # bsp_timer
     'cb',
     # radio
@@ -208,7 +206,7 @@ callbackFunctionsToChange = [
     # uart
     'txCb',
     'rxCb',
-    #===== drivers
+    # ===== drivers
     # opentimers
     'callback',
     # sixtop
@@ -216,13 +214,15 @@ callbackFunctionsToChange = [
     'cb_sf_getMetadata',
     'cb_sf_translateMetadata',
     'cb_sf_handleRCError',
+    # async
+    'async_cb',
     # opencoap
     'callbackRx',
     'callbackSendDone',
 ]
 
-functionsToChange = [
-    #===== bsp
+functions_to_change = [
+    # ===== bsp
     'mote_main',
     # supply
     'supply_init',
@@ -359,7 +359,7 @@ functionsToChange = [
     'cryptoengine_aes_ccms_dec',
     'cryptoengine_aes_ecb_enc',
     'cryptoengine_init',
-    #===== drivers
+    # ===== drivers
     # aes128
     'aes128_enc',
     # ccms
@@ -379,9 +379,6 @@ functionsToChange = [
     'openserial_printData',
     'openserial_printLog',
     'openserial_printSniffedPacket',
-    'openserial_printInfo',
-    'openserial_printError',
-    'openserial_printCritical',
     'task_openserial_debugPrint',
     'task_printInputBufferOverflow',
     'task_printWrongCRCInput',
@@ -419,12 +416,12 @@ functionsToChange = [
     'opentimers_getCurrentCompareValue',
     'opentimers_isRunning',
     'opentimers_timer_callback',
-    #===== kernel
+    # ===== kernel
     # scheduler
     'scheduler_init',
     'scheduler_start',
     'scheduler_push_task',
-    #===== openstack
+    # ===== openstack
     'openstack_init',
     # adaptive_sync
     'adaptive_sync_init',
@@ -746,42 +743,23 @@ functionsToChange = [
     'icmpv6rpl_timer_DAO_task',
     'sendDAO',
     'icmpv6rpl_daoSent',
-    # coap
-    'coap_init',
-    'coap_receive',
-    'coap_sendDone',
-    'timers_coap_fired',
-    'coap_writeLinks',
-    'coap_register',
-    'coap_send',
-    'coap_header_encode',
-    'coap_options_encode',
-    'coap_options_parse',
-    'coap_handle_proxy_scheme',
-    'coap_handle_stateless_proxy',
-    'coap_add_stateless_proxy_option',
-    'coap_forward_message',
-    'icmpv6coap_timer_cb',
-    # oscore
-    'oscore_init_security_context',
-    'oscore_get_sequence_number',
-    'oscore_protect_message',
-    'oscore_unprotect_message',
-    'oscore_encode_compressed_COSE',
-    'oscore_parse_compressed_COSE',
-    'oscore_convert_sequence_number',
-    'oscore_construct_aad',
-    # openudp
-    'openudp_init',
-    'openudp_send',
-    'openudp_sendDone',
-    'openudp_receive',
-    'openudp_debugPrint',
-    'openudp_register',
-    'openudp_sendDone_default_handler',
-    'openudp_receive_default_handler',
-    'udp_send_done_callback_ptr',
-    'udp_receive_done_callback_ptr',
+    # udp
+    'udp_transmit',
+    'udp_sendDone',
+    'udp_receive',
+    # sock
+    'sock_udp_init',
+    'sock_udp_create',
+    'sock_udp_close',
+    'sock_udp_get_local',
+    'sock_udp_get_remote',
+    'sock_udp_recv',
+    'sock_udp_send',
+    '_sock_get_local_addr',
+    'sock_receive_internal',
+    '_sock_transmit_internal',
+    # async
+    'sock_udp_set_cb',
     # idmanager
     'idmanager_init',
     'idmanager_getIsDAGroot',
@@ -811,6 +789,7 @@ functionsToChange = [
     'openqueue_sixtopGetReceivedPacket',
     'openqueue_macGetEBPacket',
     'openqueue_macGetKaPacket',
+    'openqueue_getPacketByComponent',
     'openqueue_reset_entry',
     'openqueue_reset_big_entry',
     'openqueue_macGetDIOPacket',
@@ -846,9 +825,35 @@ functionsToChange = [
     'packetfunctions_htons',
     'packetfunctions_ntohs',
     'packetfunctions_htonl',
-    #===== openapps
-    'openapps_init',
+    # ===== openweb
     'openweb_init',
+    # coap
+    'coap_init',
+    'coap_receive',
+    'coap_sendDone',
+    'timers_coap_fired',
+    'coap_writeLinks',
+    'coap_register',
+    'coap_send',
+    'coap_header_encode',
+    'coap_options_encode',
+    'coap_options_parse',
+    'coap_handle_proxy_scheme',
+    'coap_handle_stateless_proxy',
+    'coap_add_stateless_proxy_option',
+    'coap_forward_message',
+    'icmpv6coap_timer_cb',
+    # oscore
+    'oscore_init_security_context',
+    'oscore_get_sequence_number',
+    'oscore_protect_message',
+    'oscore_unprotect_message',
+    'oscore_encode_compressed_COSE',
+    'oscore_parse_compressed_COSE',
+    'oscore_convert_sequence_number',
+    'oscore_construct_aad',
+    # ===== openapps
+    'openapps_init',
     # c6t
     'c6t_init',
     'c6t_receive',
@@ -879,9 +884,7 @@ functionsToChange = [
     'cwellknown_sendDone',
     # uecho
     'uecho_init',
-    'uecho_receive',
-    'uecho_sendDone',
-    'uecho_debugPrint',
+    'uecho_handler',
     # uexpiration
     'uexpiration_init',
     'uexpiration_receive',
@@ -927,10 +930,11 @@ functionsToChange = [
     'cjoin_setIsJoined',
 ]
 
-headerFiles = [
-    #=== inc
+header_files = [
+    # === inc
     'opendefs',
-    #=== libbsp
+    'errno',
+    # === libbsp
     'board',
     'sctimer',
     'debugpins',
@@ -939,15 +943,15 @@ headerFiles = [
     'radio',
     'uart',
     'cryptoengine',
-    #=== libdrivers,
+    # === libdrivers,
     'openhdlc',
     'openserial',
     'opentimers',
     'aes128',
     'ccms',
-    #=== libkernel
+    # === libkernel
     'scheduler',
-    #=== libopenstack
+    # === libopenstack
     'openstack',
     # 02a-MAClow
     'adaptive_sync',
@@ -960,8 +964,6 @@ headerFiles = [
     'schedule',
     'sixtop',
     'msf',
-    # 02.5-MPLS
-    # TODO
     # 03a-IPHC
     'iphc',
     'frag',
@@ -973,12 +975,17 @@ headerFiles = [
     'icmpv6rpl',
     # 04-TRAN
     'udp',
+    'sock',
+    'sock_internal',
+    'sock_types',
+    'async',
+    'async_types',
     # cross-layers
     'idmanager',
     'openqueue',
     'openrandom',
     'packetfunctions',
-    #=== openapps
+    # === openapps
     'coap',
     'oscore',
     'openapps',
@@ -998,186 +1005,158 @@ headerFiles = [
     'uexpiration_monitor'
 ]
 
-def objectify(env,target,source):
-    
-    assert len(target)==1
-    assert len(source)==1
-    
+
+def objectify(env, target, source):
+    assert len(target) == 1
+    assert len(source) == 1
+
     target = target[0].abspath
     source = source[0].abspath
-    
-    basefilename = os.path.split(source)[1].split('.')[0]
-    
-    if os.path.split(source)[1].split('.')[1]=='h':
-        headerFile = True
+
+    base_filename = os.path.split(source)[1].split('.')[0]
+
+    if os.path.split(source)[1].split('.')[1] == 'h':
+        header_file = True
     else:
-        headerFile = False
-    
-    output  = []
-    output += ['objectify:']
-    output += ['- target : {0}'.format(target)]
-    output += ['- source : {0}'.format(source)]
-    output  = '\n'.join(output)
-    #print output
-    
-    #========== read
-    
-    f = open(source,'r')
+        header_file = False
+
+    # ========== read
+
+    f = open(source, 'r')
     lines = f.read()
     f.close()
-    
-    #========= modify
-    
-    #=== all files
-    
-    # add banner
-    banner    = []
-    banner   += ['/**']
-    banner   += ['DO NOT EDIT DIRECTLY!!']
-    banner   += ['']
-    banner   += ['This file was \'objectified\' by SCons as a pre-processing']
-    banner   += ['step for the building a Python extension module.']
-    banner   += ['']
-    banner   += ['This was done on {0}.'.format(datetime.datetime.now())]
-    banner   += ['*/']
-    banner   += ['']
-    banner    = '\n'.join(banner)
-    
-    lines     = banner+lines
-    
+
+    # ========= modify
+
     # update the included headers
-    for v in headerFiles+[basefilename]:
-        lines = re.sub(
-            r'\b{0}.h\b'.format(v),
-            r'{0}_obj.h'.format(v),
-            lines
-        )
-    
+    for v in header_files + [base_filename]:
+        lines = re.sub(r'\b{0}.h\b'.format(v), r'{0}_obj.h'.format(v), lines)
+
     # change callback function declaration signatures
-    def replaceCallbackFunctionDeclarations(matchObj):
-        function        = matchObj.group(1)
-        args            = matchObj.group(2)
-        
-        if args and "void" not in args:
+    def replace_cb_function_declarations(match_obj):
+        function = match_obj.group(1)
+        args = match_obj.group(2)
+
+        args_list = args.split(',')
+        try:
+            args_list.remove("void")
+        except ValueError:
+            pass
+
+        args = ','.join(args_list)
+
+        if args:
             return '{0}(OpenMote* self, {1})'.format(function, args)
         else:
             return '{0}(OpenMote* self)'.format(function)
-    
+
     lines = re.sub(
-        pattern         = r'(typedef[ \S]+_cbt\))\((.*?)\)',
-        repl            = replaceCallbackFunctionDeclarations,
-        string          = lines,
-        flags           = re.DOTALL,
+        pattern=r'(typedef[ \S]+_cb[_]*t\))\((.*?)\)',
+        repl=replace_cb_function_declarations,
+        string=lines,
+        flags=re.DOTALL,
     )
-    
+
     # comment out global variables declarations 
-    if not headerFile:
-        for v in varsToChange:
-            lines  = re.sub(
-                '.*{0}_t\s+{0}\s*;'.format(v),
+    if not header_file:
+        for v in vars_to_change:
+            lines = re.sub(
+                '.*{0}_t +{0} *;'.format(v),
                 '// declaration of global variable _{0}_ removed during objectification.'.format(v),
                 lines
             )
-    
-    # change global variables by self->* counterpart
-    if basefilename!='openwsnmodule':
-        for v in varsToChange:
-            lines = re.sub(
-                r'\b{0}\b'.format(v),
-                r'(self->{0})'.format(v),
-                lines
-            )
-    
-    # change function signatures
-    def replaceFunctions(matchObj):
-        returnType      = matchObj.group(1)
-        function        = matchObj.group(2)
-        args            = matchObj.group(3)
-        
-        if returnType in returnTypes:
-            if args and "void" not in args:
-                return '{0} {1}(OpenMote* self, {2})'.format(returnType,function, args)
-            else:
-                return '{0} {1}(OpenMote* self)'.format(returnType,function)
-        else:
-            if args and "void" not in args:
-                return '{0} {1}(self, {2})'.format(returnType,function, args)
-            else:
-                return '{0} {1}(self)'.format(returnType,function, args)
-    
-    if basefilename!='openwsnmodule':
-        for v in functionsToChange:
-            lines = re.sub(
-                pattern     = r'([\w\*]*)[ \t]*({0})[ \t]*\((.*?)\)'.format(v),
-                repl        = replaceFunctions,
-                string      = lines,
-                flags       = re.DOTALL,
-            )
-    
-    #=== .h files only
 
-    if headerFile:
+    # change global variables by self->* counterpart
+    if base_filename != 'openwsnmodule':
+        for v in vars_to_change:
+            lines = re.sub(r'\b{0}\b'.format(v), r'(self->{0})'.format(v), lines)
+
+    # change function signatures
+    def replace_functions(match_obj):
+        return_type = match_obj.group(1)
+        function = match_obj.group(2)
+        args = match_obj.group(3)
+
+        args_list = args.split(',')
+        try:
+            args_list.remove("void")
+        except ValueError:
+            pass
+
+        args = ','.join(args_list)
+
+        if return_type in return_types:
+            if args:
+                return '{0} {1}(OpenMote* self, {2})'.format(return_type, function, args)
+            else:
+                return '{0} {1}(OpenMote* self)'.format(return_type, function)
+        else:
+            if args:
+                return '{0} {1}(self, {2})'.format(return_type, function, args)
+            else:
+                return '{0} {1}(self)'.format(return_type, function, args)
+
+    if base_filename != 'openwsnmodule':
+        for v in functions_to_change:
+            lines = re.sub(
+                pattern=r'([\w\*]*)[ \t]*({0})[ \t]*\((.*?)\)'.format(v),
+                repl=replace_functions,
+                string=lines,
+                flags=re.DOTALL,
+            )
+
+    # === .h files only
+
+    if header_file:
         # include Python.h first
-        lines = re.sub(
-            r'(#include [<"]\w+\.h[>"])',
-            r'#include "Python.h"\n\n\1',
-            lines,
-            count=1
-        )
-        
+        lines = re.sub(r'(#include [<"]\w+\.h[>"])', r'#include "Python.h"\n\n\1', lines, count=1)
+
         # include openwsn module header file
         lines = re.sub(
             r'(//[=]+ prototypes [=]+)',
             r'#include "openwsnmodule_obj.h"\ntypedef struct OpenMote OpenMote;\n\n\1',
             lines,
         )
-        
-    #=== .c files only
-    
-    if not headerFile:
-        
+
+    # === .c files only
+
+    if not header_file:
+
         # change function signatures
-        def replaceCallbackFunctionCalls(matchObj):
-            operator        = matchObj.group(1)
-            function        = matchObj.group(2)
-            args            = matchObj.group(3)
-            
+        def replace_cb_function_calls(match_obj):
+            operator = match_obj.group(1)
+            function = match_obj.group(2)
+            args = match_obj.group(3)
+
             if args:
-                return '{0}{1}(self, {2})'.format(operator,function, args)
+                return '{0}{1}(self, {2})'.format(operator, function, args)
             else:
-                return '{0}{1}(self)'.format(operator,function)
-        
-        for v in callbackFunctionsToChange:
+                return '{0}{1}(self)'.format(operator, function)
+
+        for v in cb_functions_to_change:
             lines = re.sub(
-                pattern     = '(\.|->)({0})\((.*?)\)'.format(v),
-                repl        = replaceCallbackFunctionCalls,
-                string      = lines,
+                pattern='(\.|->)({0})\((.*?)\)'.format(v),
+                repl=replace_cb_function_calls,
+                string=lines,
             )
-        
+
         # modify Python module name
-        assert len(BUILD_TARGETS)==1
-        if basefilename=='openwsnmodule':
-            lines = re.sub(
-                'REPLACE_BY_PROJ_NAME',
-                BUILD_TARGETS[0],
-                lines
-            )
-    
-    #========== write
-    
-    f = open(target,'w')
+        assert len(BUILD_TARGETS) == 1
+        if base_filename == 'openwsnmodule':
+            lines = re.sub('REPLACE_BY_PROJ_NAME', BUILD_TARGETS[0], lines)
+
+    # ========== write
+
+    f = open(target, 'w')
     f.write(''.join(lines))
     f.close()
 
-if env['verbose']:
-    objectifyBuilder = Builder(
-        action = Action(objectify)
-    )
-else:
-    objectifyBuilder = Builder(
-        action = Action(objectify,'Objectifying       $SOURCE -> $TARGET.file')
-    )
 
-buildEnv.Append(BUILDERS = {'Objectify' : objectifyBuilder})
+if env['verbose']:
+    objectifyBuilder = Builder(action=Action(objectify))
+else:
+    objectifyBuilder = Builder(action=Action(objectify, 'Objectifying       $SOURCE -> $TARGET.file'))
+
+buildEnv.Append(BUILDERS={'Objectify': objectifyBuilder})
 
 Return('buildEnv')


### PR DESCRIPTION
This PR:

- migrates `uinject` and `uexpiration_monitor` to use sock
- adds `sock_udp_close`, `sock_udp_get_local`, `sock_udp_get_remote` and `sock_sendone_internal`
- reorders some header inclusion an declaration so that from RIOT only the following patch is applied:

<details><summary><b>patch</b></summary>

```diff
diff --git a/inc/opendefs.h b/inc/opendefs.h
index 593fbb3e..23b81f8f 100644
--- a/inc/opendefs.h
+++ b/inc/opendefs.h
@@ -17,7 +17,9 @@
 #include "config.h"
 #include "toolchain_defs.h"
 #include "board_info.h"
-#include "af.h"
+^M
+#include "net/af.h"^M
+// #include "af.h"^M


 //=========================== define ==========================================
diff --git a/openstack/04-TRAN/async.c b/openstack/04-TRAN/async.c
index 678e6c31..909e62fb 100644
--- a/openstack/04-TRAN/async.c
+++ b/openstack/04-TRAN/async.c
@@ -1,7 +1,14 @@
-#include "async.h"
+
+#include "net/sock/async.h"
+// #include "async.h"

 void sock_udp_set_cb(sock_udp_t *sock, sock_udp_cb_t cb, void *cb_arg)
 {
     sock->async_cb = cb;
     sock->async_cb_arg = cb_arg;
 }
+
+sock_async_ctx_t *sock_udp_get_async_ctx(sock_udp_t *sock)
+{
+    return &sock->async_ctx;
+}
diff --git a/openstack/04-TRAN/sock.c b/openstack/04-TRAN/sock.c
index 35655fd0..69e1c81e 100644
--- a/openstack/04-TRAN/sock.c
+++ b/openstack/04-TRAN/sock.c
@@ -3,7 +3,8 @@
 #if defined(OPENWSN_UDP_C)

 #include "opendefs.h"
-#include "sock.h"
+#include "net/sock/udp.h"
+// #include "sock.h"
 #include "errno.h"
 #include "packetfunctions.h"
 #include "openqueue.h"
diff --git a/openstack/04-TRAN/sock_types.h b/openstack/04-TRAN/sock_types.h
index aed84d22..6ea34d28 100644
--- a/openstack/04-TRAN/sock_types.h
+++ b/openstack/04-TRAN/sock_types.h
@@ -1,7 +1,10 @@
 #ifndef SOCK_TYPES_H
 #define SOCK_TYPES_H

-#include "sock.h"
+#include "net/sock/async.h"
+#include "net/sock/udp.h"
+#include "opendefs.h"
+// #include "sock.h"

 struct _socket {
     sock_udp_ep_t local;         /**< local end-point */
@@ -12,6 +15,7 @@ struct _socket {
 typedef struct _socket socket_t;

 struct sock_udp {
+    sock_async_ctx_t async_ctx;       /**< asynchronous event context */
     socket_t gen_sock;                /**< Generic socket */
     sock_udp_cb_t async_cb;           /**< asynchronous callback */
     OpenQueueEntry_t* txrx;
diff --git a/openstack/openstack.c b/openstack/openstack.c
index c657619a..4b1492cb 100644
--- a/openstack/openstack.c
+++ b/openstack/openstack.c
@@ -34,7 +34,8 @@
 #include "icmpv6echo.h"
 #include "icmpv6rpl.h"
 //-- 04-TRAN
-#include "sock.h"
+// #include "sock.h"^M
+#include "net/sock/udp.h"^M

 //===== application-layer
 #include "openweb.h"

```
</details>

- fixes `DEADLINE_OPTION_ENABLED` handling
- adds deprecation warning for `uexpiration` and `userialbridge`


Depends on #2 